### PR TITLE
fix(ci): Restrict NuGet publish to main branch only

### DIFF
--- a/.github/workflows/build-dotnet.yml
+++ b/.github/workflows/build-dotnet.yml
@@ -123,10 +123,10 @@ jobs:
         with:
           github_token: ${{ secrets.GITHUB_TOKEN }}
           publish_dir: ./DocumentationSite/_site
-      # Publish prerelease NuGet packages to GitHub Packages
+      # Publish prerelease NuGet packages to GitHub Packages (main branch only)
       # Release packages are published to nuget.org via the release workflow
       - name: Publish NuGet packages to GitHub Packages
-        if: always()
+        if: success() && github.ref == 'refs/heads/main'
         env:
           GH_PACKAGES_TOKEN: ${{ secrets.GH_PACKAGES_TOKEN }}
         run: |


### PR DESCRIPTION
## **User description**
## Summary

- The NuGet publish step in `build-dotnet.yml` used `if: always()`, which pushed packages on **every** workflow run — including PR builds and failed builds
- Changed to `if: success() && github.ref == 'refs/heads/main'` so packages only publish after a successful build on the `main` branch
- This stops polluting GitHub Packages with WIP prerelease versions from PR branches

## Test plan

- [x] Verify the workflow YAML is syntactically correct
- [ ] After merge, confirm a push to `main` still publishes packages
- [ ] Confirm PR builds no longer attempt NuGet publish

🤖 Generated with [Claude Code](https://claude.com/claude-code)


___

## **CodeAnt-AI Description**
Stop publishing prerelease NuGet packages from PRs and failed builds

### What Changed
- NuGet packages now publish only after a successful build on the `main` branch
- PR builds and failed workflow runs no longer upload prerelease packages to GitHub Packages
- The workflow note now makes it clear that package publishing is limited to `main`

### Impact
`✅ Fewer unwanted package uploads`
`✅ Cleaner GitHub Packages feed`
`✅ No prerelease packages from PR builds`
<details>
<summary><strong>💡 Usage Guide</strong></summary>

### Checking Your Pull Request
Every time you make a pull request, our system automatically looks through it. We check for security issues, mistakes in how you're setting up your infrastructure, and common code problems. We do this to make sure your changes are solid and won't cause any trouble later.

### Talking to CodeAnt AI
Got a question or need a hand with something in your pull request? You can easily get in touch with CodeAnt AI right here. Just type the following in a comment on your pull request, and replace "Your question here" with whatever you want to ask:
<pre>
<code>@codeant-ai ask: Your question here</code>
</pre>
This lets you have a chat with CodeAnt AI about your pull request, making it easier to understand and improve your code.

#### Example
<pre>
<code>@codeant-ai ask: Can you suggest a safer alternative to storing this secret?</code>
</pre>

### Preserve Org Learnings with CodeAnt
You can record team preferences so CodeAnt AI applies them in future reviews. Reply directly to the specific CodeAnt AI suggestion (in the same thread) and replace "Your feedback here" with your input:
<pre>
<code>@codeant-ai: Your feedback here</code>
</pre>
This helps CodeAnt AI learn and adapt to your team's coding style and standards.

#### Example
<pre>
<code>@codeant-ai: Do not flag unused imports.</code>
</pre>

### Retrigger review
Ask CodeAnt AI to review the PR again, by typing:
<pre>
<code>@codeant-ai: review</code>
</pre>

### Check Your Repository Health
To analyze the health of your code repository, visit our dashboard at [https://app.codeant.ai](https://app.codeant.ai). This tool helps you identify potential issues and areas for improvement in your codebase, ensuring your repository maintains high standards of code health.

</details>


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated CI/CD workflow to ensure NuGet package publishing only occurs on successful builds from the main branch, improving release reliability.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->