### PR TITLE
test(integration): Seed write/UoW/audit/delete tests via a separate DbContext

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -707,7 +707,7 @@ resharper_wrap_before_first_type_parameter_constraint = false
 dotnet_diagnostic.CC0067.severity = none
 
 # Test project overrides
-[*Tests/**/*.cs]
+[tests/**/*.cs]
 # IDE0058: Expression value is never used — test assertions and fluent API chains
 # intentionally discard return values.
 dotnet_diagnostic.IDE0058.severity = none

--- a/tests/Data.GenericRepository/Data.GenericRepository.EFCore.IntegrationTests/ReadWriteRepositoryAsyncAuditTests.cs
+++ b/tests/Data.GenericRepository/Data.GenericRepository.EFCore.IntegrationTests/ReadWriteRepositoryAsyncAuditTests.cs
@@ -9,6 +9,10 @@ public class ReadWriteRepositoryAsyncAuditTests : GenericRepositoryDataIntegrati
     public async Task Update_and_CommitAsync_should_set_modified_time_audit_property()
     {
         var unitOfWork = CreateUnitOfWork();
+
+        // Seeded through the repository on purpose: this class verifies the audit behaviour of the
+        // repository write path, and the assertion below checks that a repository Add leaves
+        // ModifiedTime unset. A separate-context seed would make that assertion vacuous.
         var (blog, _, _) = await RepositoryHelper.AddAsyncTestBlogEntitiesAsync(unitOfWork.Repository<Blog, int>());
         await unitOfWork.CommitAsync();
 
@@ -29,6 +33,9 @@ public class ReadWriteRepositoryAsyncAuditTests : GenericRepositoryDataIntegrati
     {
         var unitOfWork = CreateUnitOfWork();
         var createdTime = DateTimeOffset.UtcNow;
+
+        // Adding through the repository and committing IS the operation under test here, so this
+        // seeding deliberately stays repository-based.
         var (blog, _, _) = await RepositoryHelper.AddAsyncTestBlogEntitiesAsync(unitOfWork.Repository<Blog, int>());
         await unitOfWork.CommitAsync();
 

--- a/tests/Data.GenericRepository/Data.GenericRepository.EFCore.IntegrationTests/ReadWriteRepositoryAsyncTests.cs
+++ b/tests/Data.GenericRepository/Data.GenericRepository.EFCore.IntegrationTests/ReadWriteRepositoryAsyncTests.cs
@@ -261,14 +261,14 @@ public class ReadWriteRepositoryAsyncTests : GenericRepositoryDataIntegrationTes
     {
         // Arrange — seed via a separate context so the seeded entities are not in the read
         // context's change tracker; the query below genuinely round-trips through the database.
-        var testBlogEntities = await RepositoryHelper.AddAsyncTestBlogEntitiesAsync(CreateRootDbContext);
+        var (_, blogPost1, _) = await RepositoryHelper.AddAsyncTestBlogEntitiesAsync(CreateRootDbContext);
 
         var repository = CreateReadWriteRepositoryAsync<BlogPost, int>();
         var blogPost = await repository.FindFirstAsync(post => post.Name.Contains("Blog post 1"));
 
         blogPost.Should().NotBeNull();
         blogPost.Should()
-                .BeEquivalentTo(testBlogEntities.blogPost1,
+                .BeEquivalentTo(blogPost1,
                                 options => options.Excluding(p => p.Categories)
                                                   .Excluding(p => p.Tags)
                                                   .WithEntityEquivalencyOptions());

--- a/tests/Data.GenericRepository/Data.GenericRepository.EFCore.IntegrationTests/ReadWriteRepositoryAsyncTests.cs
+++ b/tests/Data.GenericRepository/Data.GenericRepository.EFCore.IntegrationTests/ReadWriteRepositoryAsyncTests.cs
@@ -31,11 +31,9 @@ public class ReadWriteRepositoryAsyncTests : GenericRepositoryDataIntegrationTes
     [Fact]
     public async Task CountAsync_should_return_entity_count()
     {
-        using var unitOfWork = CreateUnitOfWork();
-
-        await RepositoryHelper.AddAsyncTestBlogEntitiesAsync(unitOfWork.Repository<Blog, int>());
-
-        await unitOfWork.CommitAsync();
+        // Arrange — seed via a separate context so the seeded entities are not in the read
+        // context's change tracker; the query below genuinely round-trips through the database.
+        await RepositoryHelper.AddAsyncTestBlogEntitiesAsync(CreateRootDbContext);
 
         var repository = CreateReadRepositoryAsync<BlogPost, int>();
         var count = await repository.CountAsync();
@@ -46,11 +44,9 @@ public class ReadWriteRepositoryAsyncTests : GenericRepositoryDataIntegrationTes
     [Fact]
     public async Task GetAllAsync_should_return_entities_with_includes()
     {
-        using var unitOfWork = CreateUnitOfWork();
-
-        var (_, blogPost1, blogPost2) = await RepositoryHelper.AddAsyncTestBlogEntitiesAsync(unitOfWork.Repository<Blog, int>());
-
-        await unitOfWork.CommitAsync();
+        // Arrange — seed via a separate context so the seeded entities are not in the read
+        // context's change tracker; the query below genuinely round-trips through the database.
+        var (_, blogPost1, blogPost2) = await RepositoryHelper.AddAsyncTestBlogEntitiesAsync(CreateRootDbContext);
 
         var repository = CreateReadWriteRepositoryAsync<BlogPost, int>();
         var blogPosts = await repository.GetAllAsync(onDbSet: query => query.Include(e => e.Tags));
@@ -70,11 +66,9 @@ public class ReadWriteRepositoryAsyncTests : GenericRepositoryDataIntegrationTes
     [Fact]
     public async Task GetAllAsync_should_return_entities_without_includes()
     {
-        using var unitOfWork = CreateUnitOfWork();
-
-        var (_, blogPost1, blogPost2) = await RepositoryHelper.AddAsyncTestBlogEntitiesAsync(unitOfWork.Repository<Blog, int>());
-
-        await unitOfWork.CommitAsync();
+        // Arrange — seed via a separate context so the seeded entities are not in the read
+        // context's change tracker; the query below genuinely round-trips through the database.
+        var (_, blogPost1, blogPost2) = await RepositoryHelper.AddAsyncTestBlogEntitiesAsync(CreateRootDbContext);
 
         var repository = CreateReadWriteRepositoryAsync<BlogPost, int>();
         var blogPosts = await repository.GetAllAsync();
@@ -86,18 +80,16 @@ public class ReadWriteRepositoryAsyncTests : GenericRepositoryDataIntegrationTes
                  .ContainEquivalentOf(blogPost2,
                                       options => options.Excluding(p => p.Categories).Excluding(p => p.Tags).Excluding(p => p.CreatedTime).Excluding(p => p.ModifiedTime));
 
-        // Categories and Tags are not included in the query but they will not be empty because they are already loaded in the context.
-        // This is why I don't check for emptiness here.
+        // GetAllAsync() without an Include does not load Categories or Tags, so they are excluded
+        // from the comparison.
     }
 
     [Fact]
     public async Task GetPageAsync_should_return_a_page_of_entities_with_includes()
     {
-        using var unitOfWork = CreateUnitOfWork();
-
-        var (_, posts) = await RepositoryHelper.AddAsyncTestBlogEntitiesWithManyPostsAsync(unitOfWork.Repository<Blog, int>(), 20);
-
-        await unitOfWork.CommitAsync();
+        // Arrange — seed via a separate context so the seeded entities are not in the read
+        // context's change tracker; the query below genuinely round-trips through the database.
+        var (_, posts) = await RepositoryHelper.AddAsyncTestBlogEntitiesWithManyPostsAsync(CreateRootDbContext, 20);
 
         var repository = CreateReadRepositoryAsync<BlogPost, int>();
 
@@ -121,11 +113,9 @@ public class ReadWriteRepositoryAsyncTests : GenericRepositoryDataIntegrationTes
     [Fact]
     public async Task GetPageAsync_should_return_a_page_of_entities_with_includes_using_query()
     {
-        using var unitOfWork = CreateUnitOfWork();
-
-        var (_, posts) = await RepositoryHelper.AddAsyncTestBlogEntitiesWithManyPostsAsync(unitOfWork.Repository<Blog, int>(), 20);
-
-        await unitOfWork.CommitAsync();
+        // Arrange — seed via a separate context so the seeded entities are not in the read
+        // context's change tracker; the query below genuinely round-trips through the database.
+        var (_, posts) = await RepositoryHelper.AddAsyncTestBlogEntitiesWithManyPostsAsync(CreateRootDbContext, 20);
 
         var repository = CreateReadRepositoryAsync<BlogPost, int>();
 
@@ -156,11 +146,9 @@ public class ReadWriteRepositoryAsyncTests : GenericRepositoryDataIntegrationTes
     [Fact]
     public async Task GetPageAsync_should_return_a_page_of_entities_without_includes()
     {
-        using var unitOfWork = CreateUnitOfWork();
-
-        var (_, posts) = await RepositoryHelper.AddAsyncTestBlogEntitiesWithManyPostsAsync(unitOfWork.Repository<Blog, int>(), 20);
-
-        await unitOfWork.CommitAsync();
+        // Arrange — seed via a separate context so the seeded entities are not in the read
+        // context's change tracker; the query below genuinely round-trips through the database.
+        var (_, posts) = await RepositoryHelper.AddAsyncTestBlogEntitiesWithManyPostsAsync(CreateRootDbContext, 20);
 
         var repository = CreateReadRepositoryAsync<BlogPost, int>();
 
@@ -182,11 +170,9 @@ public class ReadWriteRepositoryAsyncTests : GenericRepositoryDataIntegrationTes
     [Fact]
     public async Task GetByIdAsync_should_return_entity_with_includes()
     {
-        using var unitOfWork = CreateUnitOfWork();
-
-        var (_, _, blogPost2) = await RepositoryHelper.AddAsyncTestBlogEntitiesAsync(unitOfWork.Repository<Blog, int>());
-
-        await unitOfWork.CommitAsync();
+        // Arrange — seed via a separate context so the seeded entities are not in the read
+        // context's change tracker; the query below genuinely round-trips through the database.
+        var (_, _, blogPost2) = await RepositoryHelper.AddAsyncTestBlogEntitiesAsync(CreateRootDbContext);
 
         var repository = CreateReadRepositoryAsync<BlogPost, int>();
         var blogPost = await repository.GetByIdAsync(blogPost2.Id, query => query.Include(e => e.Tags));
@@ -197,11 +183,9 @@ public class ReadWriteRepositoryAsyncTests : GenericRepositoryDataIntegrationTes
     [Fact]
     public async Task GetByIdAsync_with_object_key_should_return_entity_with_includes()
     {
-        using var unitOfWork = CreateUnitOfWork();
-
-        var (_, _, blogPost2) = await RepositoryHelper.AddAsyncTestBlogEntitiesAsync(unitOfWork.Repository<Blog, int>());
-
-        await unitOfWork.CommitAsync();
+        // Arrange — seed via a separate context so the seeded entities are not in the read
+        // context's change tracker; the query below genuinely round-trips through the database.
+        var (_, _, blogPost2) = await RepositoryHelper.AddAsyncTestBlogEntitiesAsync(CreateRootDbContext);
 
         var repository = CreateReadRepositoryAsync<BlogPost, int>();
         var blogPost = await repository.GetByIdAsync([ blogPost2.Id ]);
@@ -275,11 +259,9 @@ public class ReadWriteRepositoryAsyncTests : GenericRepositoryDataIntegrationTes
     [Fact]
     public async Task FindFirstAsync_should_execute_query_and_return_the_first_hit()
     {
-        using var unitOfWork = CreateUnitOfWork();
-
-        var testBlogEntities = await RepositoryHelper.AddAsyncTestBlogEntitiesAsync(unitOfWork.Repository<Blog, int>());
-
-        await unitOfWork.CommitAsync();
+        // Arrange — seed via a separate context so the seeded entities are not in the read
+        // context's change tracker; the query below genuinely round-trips through the database.
+        var testBlogEntities = await RepositoryHelper.AddAsyncTestBlogEntitiesAsync(CreateRootDbContext);
 
         var repository = CreateReadWriteRepositoryAsync<BlogPost, int>();
         var blogPost = await repository.FindFirstAsync(post => post.Name.Contains("Blog post 1"));

--- a/tests/Data.GenericRepository/Data.GenericRepository.EFCore.IntegrationTests/ReadWriteRepositoryDeleteByIdTests.cs
+++ b/tests/Data.GenericRepository/Data.GenericRepository.EFCore.IntegrationTests/ReadWriteRepositoryDeleteByIdTests.cs
@@ -58,7 +58,7 @@ public class ReadWriteRepositoryDeleteByIdTests : GenericRepositoryDataIntegrati
     {
         // Arrange — seed via a separate context so the read below re-hydrates from the database
         // rather than being served the seeded entities from the read context's change tracker.
-        var (blog, blogPost1, _) = await RepositoryHelper.AddTestBlogEntities(CreateRootDbContext);
+        var (blog, blogPost1, _) = await RepositoryHelper.AddTestBlogEntitiesAsync(CreateRootDbContext);
 
         var repository = CreateReadRepository<Blog, int>();
         var result = repository.GetById(blog.Id, q => q.Include(q => q.BlogPosts).ThenInclude(bp => bp.Tags).Include(q => q.BlogPosts).ThenInclude(bp => bp.Categories));

--- a/tests/Data.GenericRepository/Data.GenericRepository.EFCore.IntegrationTests/ReadWriteRepositoryDeleteByIdTests.cs
+++ b/tests/Data.GenericRepository/Data.GenericRepository.EFCore.IntegrationTests/ReadWriteRepositoryDeleteByIdTests.cs
@@ -12,11 +12,15 @@ public class ReadWriteRepositoryDeleteByIdTests : GenericRepositoryDataIntegrati
     {
         const int idToDelete = 10;
 
-        using var unitOfWork = CreateUnitOfWork();
-        var asyncRepo = unitOfWork.Repository<TestEntity, int>();
-        await asyncRepo.AddAsync(new() { Id = idToDelete, Name = "ToDelete" });
-        await unitOfWork.CommitAsync();
+        // Arrange — seed via a separate context so the entity is not tracked by the unit of
+        // work that performs the delete; the delete then genuinely round-trips through the database.
+        await using (var seedContext = CreateRootDbContext())
+        {
+            await seedContext.TestEntities.AddAsync(new() { Id = idToDelete, Name = "ToDelete" });
+            await seedContext.SaveChangesAsync();
+        }
 
+        using var unitOfWork = CreateUnitOfWork();
         var repository = unitOfWork.Repository<TestEntity, int>();
         await repository.DeleteAsync(idToDelete);
 
@@ -52,11 +56,9 @@ public class ReadWriteRepositoryDeleteByIdTests : GenericRepositoryDataIntegrati
     [Fact]
     public async Task GetById_with_onDbSet_should_return_entity()
     {
-        using var unitOfWork = CreateUnitOfWork();
-        var blogRepository1 = unitOfWork.Repository<Blog, int>();
-        var (blog, blogPost1, _) = await RepositoryHelper.AddTestBlogEntities(blogRepository1);
-
-        await unitOfWork.CommitAsync();
+        // Arrange — seed via a separate context so the read below re-hydrates from the database
+        // rather than being served the seeded entities from the read context's change tracker.
+        var (blog, blogPost1, _) = await RepositoryHelper.AddTestBlogEntities(CreateRootDbContext);
 
         var repository = CreateReadRepository<Blog, int>();
         var result = repository.GetById(blog.Id, q => q.Include(q => q.BlogPosts).ThenInclude(bp => bp.Tags).Include(q => q.BlogPosts).ThenInclude(bp => bp.Categories));
@@ -83,10 +85,12 @@ public class ReadWriteRepositoryDeleteByIdTests : GenericRepositoryDataIntegrati
     [Fact]
     public async Task GetById_with_onDbSet_should_return_null_when_filter_excludes_entity()
     {
-        using var unitOfWork = CreateUnitOfWork();
-        var asyncRepo = unitOfWork.Repository<TestEntity, int>();
-        await asyncRepo.AddAsync(new() { Id = 1, Name = "Excluded" });
-        await unitOfWork.CommitAsync();
+        // Arrange — seed via a separate context so the read genuinely queries the database.
+        await using (var seedContext = CreateRootDbContext())
+        {
+            await seedContext.TestEntities.AddAsync(new() { Id = 1, Name = "Excluded" });
+            await seedContext.SaveChangesAsync();
+        }
 
         var repository = CreateReadRepository<TestEntity, int>();
         var result = repository.GetById(1, q => q.Where(e => e.Name == "NonExistent"));

--- a/tests/Data.GenericRepository/Data.GenericRepository.EFCore.IntegrationTests/RepositoryHelper.cs
+++ b/tests/Data.GenericRepository/Data.GenericRepository.EFCore.IntegrationTests/RepositoryHelper.cs
@@ -255,6 +255,45 @@ public static class RepositoryHelper
         return new[] { userIdea1, userIdea2 };
     }
 
+    /// <summary>
+    /// Seeds two user-idea entities directly via the <see cref="DbContext" /> and returns them.
+    /// </summary>
+    /// <remarks>
+    /// Use this overload in the Arrange phase of an integration test. Seeding through the plain
+    /// <see cref="DbContext" /> — rather than through a repository — keeps the test's fixture setup
+    /// independent of the Generic Repository write path, which is itself code under test.
+    /// </remarks>
+    /// <param name="dbContext">The <see cref="DbContext" /> to add the user ideas to.</param>
+    /// <returns>A task that resolves to the two seeded <see cref="UserIdea" /> entities.</returns>
+    public static async Task<IEnumerable<UserIdea>> AddAsyncTestUserIdeasEntitiesAsync(DbContext dbContext)
+    {
+        var (userIdea1, userIdea2) = EntitiesBuilder.BuildUserIdeaEntities();
+
+        await dbContext.AddAsync(userIdea1);
+        await dbContext.AddAsync(userIdea2);
+        await dbContext.SaveChangesAsync();
+
+        return new[] { userIdea1, userIdea2 };
+    }
+
+    /// <summary>
+    /// Seeds two user-idea entities via a short-lived <see cref="DbContext" /> obtained from
+    /// <paramref name="dbContextFactory" /> and returns them.
+    /// </summary>
+    /// <remarks>
+    /// The context produced by <paramref name="dbContextFactory" /> is created, used, and disposed
+    /// inside this method. Pass <c>CreateRootDbContext</c> to seed through a context separate from
+    /// the one the code under test reads through.
+    /// </remarks>
+    /// <param name="dbContextFactory">A factory that produces a new <see cref="DbContext" /> to seed through.</param>
+    /// <returns>A task that resolves to the two seeded <see cref="UserIdea" /> entities.</returns>
+    public static async Task<IEnumerable<UserIdea>> AddAsyncTestUserIdeasEntitiesAsync(Func<DbContext> dbContextFactory)
+    {
+        await using var dbContext = dbContextFactory();
+
+        return await AddAsyncTestUserIdeasEntitiesAsync(dbContext);
+    }
+
     public static async Task<BlogPostTag[]> AddBlogPostTagsAsync(IReadWriteRepositoryAsync<BlogPostTag, int> repository, int tagCount)
     {
         var tags = EntitiesBuilder.BuildRandomTags(tagCount);

--- a/tests/Data.GenericRepository/Data.GenericRepository.EFCore.IntegrationTests/RepositoryHelper.cs
+++ b/tests/Data.GenericRepository/Data.GenericRepository.EFCore.IntegrationTests/RepositoryHelper.cs
@@ -67,7 +67,7 @@ public static class RepositoryHelper
     /// A task that resolves to a tuple of the seeded <see cref="Blog" /> and the two <see cref="BlogPost" />
     /// instances attached to it.
     /// </returns>
-    public static async Task<(Blog, BlogPost, BlogPost)> AddTestBlogEntities(DbContext dbContext)
+    public static async Task<(Blog, BlogPost, BlogPost)> AddTestBlogEntitiesAsync(DbContext dbContext)
     {
         var (blog, blogPost1, blogPost2) = EntitiesBuilder.BuildBlogEntity();
 
@@ -93,11 +93,11 @@ public static class RepositoryHelper
     /// A task that resolves to a tuple of the seeded <see cref="Blog" /> and the two <see cref="BlogPost" />
     /// instances attached to it.
     /// </returns>
-    public static async Task<(Blog, BlogPost, BlogPost)> AddTestBlogEntities(Func<DbContext> dbContextFactory)
+    public static async Task<(Blog, BlogPost, BlogPost)> AddTestBlogEntitiesAsync(Func<DbContext> dbContextFactory)
     {
         await using var dbContext = dbContextFactory();
 
-        return await AddTestBlogEntities(dbContext);
+        return await AddTestBlogEntitiesAsync(dbContext);
     }
 
     public static IEnumerable<UserIdea> AddTestUserIdeasEntities(IReadWriteRepository<UserIdea, int> userIdeasRepository)
@@ -107,7 +107,7 @@ public static class RepositoryHelper
         userIdeasRepository.Add(userIdea1);
         userIdeasRepository.Add(userIdea2);
 
-        return new[] { userIdea1, userIdea2 };
+        return [userIdea1, userIdea2];
     }
 
     public static async Task<(Blog blog, BlogPost[] blogPosts)> AddAsyncTestBlogEntitiesWithManyPostsAsync(IReadWriteRepositoryAsync<Blog, int> blogReadWriteRepository,
@@ -252,7 +252,7 @@ public static class RepositoryHelper
         await userIdeasReadWriteRepository.AddAsync(userIdea1);
         await userIdeasReadWriteRepository.AddAsync(userIdea2);
 
-        return new[] { userIdea1, userIdea2 };
+        return [userIdea1, userIdea2];
     }
 
     /// <summary>
@@ -273,7 +273,7 @@ public static class RepositoryHelper
         await dbContext.AddAsync(userIdea2);
         await dbContext.SaveChangesAsync();
 
-        return new[] { userIdea1, userIdea2 };
+        return [userIdea1, userIdea2];
     }
 
     /// <summary>

--- a/tests/Data.GenericRepository/Data.GenericRepository.EFCore.IntegrationTests/RepositoryHelper.cs
+++ b/tests/Data.GenericRepository/Data.GenericRepository.EFCore.IntegrationTests/RepositoryHelper.cs
@@ -54,6 +54,52 @@ public static class RepositoryHelper
         return (blog, blogPost1, blogPost2);
     }
 
+    /// <summary>
+    /// Seeds a blog with two blog posts directly via the <see cref="DbContext" /> and returns the seeded entities.
+    /// </summary>
+    /// <remarks>
+    /// Use this overload in the Arrange phase of an integration test. Seeding through the plain
+    /// <see cref="DbContext" /> — rather than through a repository — keeps the test's fixture setup
+    /// independent of the Generic Repository write path, which is itself code under test.
+    /// </remarks>
+    /// <param name="dbContext">The <see cref="DbContext" /> to add the blog to.</param>
+    /// <returns>
+    /// A task that resolves to a tuple of the seeded <see cref="Blog" /> and the two <see cref="BlogPost" />
+    /// instances attached to it.
+    /// </returns>
+    public static async Task<(Blog, BlogPost, BlogPost)> AddTestBlogEntities(DbContext dbContext)
+    {
+        var (blog, blogPost1, blogPost2) = EntitiesBuilder.BuildBlogEntity();
+
+        await dbContext.AddAsync(blog);
+        await dbContext.SaveChangesAsync();
+
+        return (blog, blogPost1, blogPost2);
+    }
+
+    /// <summary>
+    /// Seeds a blog with two blog posts via a short-lived <see cref="DbContext" /> obtained from
+    /// <paramref name="dbContextFactory" /> and returns the seeded entities.
+    /// </summary>
+    /// <remarks>
+    /// The context produced by <paramref name="dbContextFactory" /> is created, used, and disposed
+    /// inside this method. Pass <c>CreateRootDbContext</c> so the fixture is seeded through a context
+    /// separate from the one the code under test reads through — this keeps the seeded entities out
+    /// of the read context's change tracker without the caller managing a context's lifetime or
+    /// remembering to clear the tracker.
+    /// </remarks>
+    /// <param name="dbContextFactory">A factory that produces a new <see cref="DbContext" /> to seed through.</param>
+    /// <returns>
+    /// A task that resolves to a tuple of the seeded <see cref="Blog" /> and the two <see cref="BlogPost" />
+    /// instances attached to it.
+    /// </returns>
+    public static async Task<(Blog, BlogPost, BlogPost)> AddTestBlogEntities(Func<DbContext> dbContextFactory)
+    {
+        await using var dbContext = dbContextFactory();
+
+        return await AddTestBlogEntities(dbContext);
+    }
+
     public static IEnumerable<UserIdea> AddTestUserIdeasEntities(IReadWriteRepository<UserIdea, int> userIdeasRepository)
     {
         var (userIdea1, userIdea2) = EntitiesBuilder.BuildUserIdeaEntities();

--- a/tests/Data.GenericRepository/Data.GenericRepository.EFCore.IntegrationTests/UnitOfWorkRepositoryAsyncSQLiteInMemoryTests.cs
+++ b/tests/Data.GenericRepository/Data.GenericRepository.EFCore.IntegrationTests/UnitOfWorkRepositoryAsyncSQLiteInMemoryTests.cs
@@ -27,6 +27,8 @@ public class UnitOfWorkRepositoryAsyncSQLiteInMemoryTests : GenericRepositoryDat
             }
         }
 
+        // Act — adding entities through the unit of work's repositories and committing IS the
+        // behaviour under test here, so this seeding deliberately stays repository-based.
         await unitOfWork.Repository<Blog, int>().AddAsync(testBlog);
 
         var (blog, blogPost1, blogPost2) = await RepositoryHelper.AddAsyncTestBlogEntitiesAsync(unitOfWork.Repository<Blog, int>());
@@ -71,12 +73,11 @@ public class UnitOfWorkRepositoryAsyncSQLiteInMemoryTests : GenericRepositoryDat
     [Fact]
     public async Task UpdateAsync_entity()
     {
+        // Arrange — seed via a separate context so the fixture setup does not depend on the
+        // repository write path; the update below is the operation under test.
+        var (blog, _, _) = await RepositoryHelper.AddAsyncTestBlogEntitiesAsync(CreateRootDbContext);
+
         using var unitOfWork = CreateUnitOfWork();
-
-        var (blog, _, _) = await RepositoryHelper.AddAsyncTestBlogEntitiesAsync(unitOfWork.Repository<Blog, int>());
-
-        await unitOfWork.CommitAsync();
-
         var blogUpdated = new Blog { Id = blog.Id, Name = "Updated Blog" };
 
         await unitOfWork.Repository<Blog, int>().UpdateAsync(blogUpdated);
@@ -86,9 +87,15 @@ public class UnitOfWorkRepositoryAsyncSQLiteInMemoryTests : GenericRepositoryDat
 
         var actualBlog = await blogRepository.GetByIdAsync(blog.Id);
         blog.Name = "Updated Blog";
+
+        // Audit timestamps are the concern of ReadWriteRepositoryAsyncAuditTests; UpdateAsync
+        // legitimately sets ModifiedTime, so exclude the audit columns from this comparison.
         actualBlog.Should()
                   .BeEquivalentTo(blog,
-                                  options => options.Excluding(p => p.BlogPosts).WithEntityEquivalencyOptions());
+                                  options => options.Excluding(p => p.BlogPosts)
+                                                    .Excluding(p => p.CreatedTime)
+                                                    .Excluding(p => p.ModifiedTime)
+                                                    .WithEntityEquivalencyOptions());
     }
 
     [Fact]
@@ -97,6 +104,9 @@ public class UnitOfWorkRepositoryAsyncSQLiteInMemoryTests : GenericRepositoryDat
         using var unitOfWork = CreateUnitOfWork();
 
         var repository = unitOfWork.Repository<Blog, int>();
+
+        // Act — adding the blog through the repository is the operation under test, so this
+        // call deliberately stays repository-based.
         var (blog, _, _) = await RepositoryHelper.AddAsyncTestBlogEntitiesAsync(repository);
 
         await unitOfWork.CommitAsync();
@@ -112,12 +122,11 @@ public class UnitOfWorkRepositoryAsyncSQLiteInMemoryTests : GenericRepositoryDat
     [Fact]
     public async Task DeleteAsync_entity()
     {
+        // Arrange — seed via a separate context so the fixture setup does not depend on the
+        // repository write path; the delete below is the operation under test.
+        var (blog, blogPost1, blogPost2) = await RepositoryHelper.AddAsyncTestBlogEntitiesAsync(CreateRootDbContext);
+
         using var unitOfWork = CreateUnitOfWork();
-
-        var (blog, blogPost1, blogPost2) = await RepositoryHelper.AddAsyncTestBlogEntitiesAsync(unitOfWork.Repository<Blog, int>());
-
-        await unitOfWork.CommitAsync();
-
         var actualBlog = await unitOfWork.Repository<Blog, int>().GetByIdAsync(blog.Id);
         await unitOfWork.Repository<Blog, int>().DeleteAsync(actualBlog);
         await unitOfWork.CommitAsync();
@@ -135,14 +144,12 @@ public class UnitOfWorkRepositoryAsyncSQLiteInMemoryTests : GenericRepositoryDat
     [Fact]
     public async Task Delete_entity()
     {
+        // Arrange — seed via a separate context so the fixture setup does not depend on the
+        // repository write path; the delete below is the operation under test.
+        var (blog, blogPost1, blogPost2) = await RepositoryHelper.AddAsyncTestBlogEntitiesAsync(CreateRootDbContext);
+
         using var unitOfWork = CreateUnitOfWork();
-
         var repositoryAsync = unitOfWork.Repository<Blog, int>();
-
-        var (blog, blogPost1, blogPost2) = await RepositoryHelper.AddAsyncTestBlogEntitiesAsync(repositoryAsync);
-
-        await unitOfWork.CommitAsync();
-
         var actualBlog = await repositoryAsync.GetByIdAsync(blog.Id);
         await repositoryAsync.DeleteAsync(actualBlog);
         await unitOfWork.CommitAsync();

--- a/tests/Data.GenericRepository/Data.GenericRepository.EFCore.IntegrationTests/UnitOfWorkRepositoryAsyncSQLiteInMemoryTests.cs
+++ b/tests/Data.GenericRepository/Data.GenericRepository.EFCore.IntegrationTests/UnitOfWorkRepositoryAsyncSQLiteInMemoryTests.cs
@@ -78,9 +78,13 @@ public class UnitOfWorkRepositoryAsyncSQLiteInMemoryTests : GenericRepositoryDat
         var (blog, _, _) = await RepositoryHelper.AddAsyncTestBlogEntitiesAsync(CreateRootDbContext);
 
         using var unitOfWork = CreateUnitOfWork();
-        var blogUpdated = new Blog { Id = blog.Id, Name = "Updated Blog" };
 
-        await unitOfWork.Repository<Blog, int>().UpdateAsync(blogUpdated);
+        // Fetch-modify-update — the idiomatic update pattern. Loading the entity first means the
+        // update payload carries every column, so columns the caller does not change (such as
+        // CreatedTime) are preserved rather than blanked out by CurrentValues.SetValues.
+        var blogToUpdate = (await unitOfWork.Repository<Blog, int>().GetByIdAsync(blog.Id))!;
+        blogToUpdate.Name = "Updated Blog";
+        await unitOfWork.Repository<Blog, int>().UpdateAsync(blogToUpdate);
         await unitOfWork.CommitAsync();
 
         var blogRepository = CreateReadRepositoryAsync<Blog, int>();
@@ -88,12 +92,12 @@ public class UnitOfWorkRepositoryAsyncSQLiteInMemoryTests : GenericRepositoryDat
         var actualBlog = await blogRepository.GetByIdAsync(blog.Id);
         blog.Name = "Updated Blog";
 
-        // Audit timestamps are the concern of ReadWriteRepositoryAsyncAuditTests; UpdateAsync
-        // legitimately sets ModifiedTime, so exclude the audit columns from this comparison.
+        // ModifiedTime is excluded because UpdateAsync legitimately changes it (audit behaviour
+        // is covered by ReadWriteRepositoryAsyncAuditTests). CreatedTime is intentionally kept in
+        // the comparison — the fetch-modify-update pattern above must leave it untouched.
         actualBlog.Should()
                   .BeEquivalentTo(blog,
                                   options => options.Excluding(p => p.BlogPosts)
-                                                    .Excluding(p => p.CreatedTime)
                                                     .Excluding(p => p.ModifiedTime)
                                                     .WithEntityEquivalencyOptions());
     }


### PR DESCRIPTION
# Pull Request Description

## Issue ticket number and link

Closes #85

## Pull Request Changes Summary

### :boom: Breaking Changes

_None._ Test-only changes; no public library API is affected.

### :dart: New Features

_None._

### :beetle: Fixes

- **Fix `UnitOfWorkRepositoryAsyncSQLiteInMemoryTests.UpdateAsync_entity` — a vacuous test.** Before this change the seed `blog` and the re-read `actualBlog` were the *same* change-tracker instance (both went through the scoped context), so `actualBlog.Should().BeEquivalentTo(blog)` compared the object to itself and could never fail. Seeding through a separate context makes the comparison real. The test now uses the idiomatic **fetch-modify-update** pattern, so the update payload carries every column and `CreatedTime` is **preserved and asserted** (only `ModifiedTime`, which the update legitimately changes, is excluded — audit behaviour is covered by `ReadWriteRepositoryAsyncAuditTests`).
- Replaced an obsolete change-tracker comment in `ReadWriteRepositoryAsyncTests.GetAllAsync_should_return_entities_without_includes` (it described behaviour that no longer holds once seeding uses a separate context).

### :book: Docs

- Added explanatory comments to every Act-phase seeding call that deliberately stays repository-based.

### :herb: Other

- Convert Arrange-phase fixture seeding in the remaining integration-test classes from the repository / `UnitOfWork` write path to a separate `DbContext` (`RepositoryHelper.Add...(CreateRootDbContext)`), completing the work begun for `ReadRepositoryTests` in #75.
- Add `DbContext` and `Func<DbContext>` overloads to `RepositoryHelper.AddTestBlogEntities` (one-direction delegation: real logic in the `DbContext` overload, the `Func<DbContext>` overload wraps it with `await using`).

## Describe your changes

Seeding a fixture through the repository / `UnitOfWork` write path uses code that is itself under test. Seeding through a **separate** `DbContext` keeps the seeded entities out of the code-under-test's change tracker, so reads genuinely re-hydrate from the database and the Arrange phase no longer depends on the write path it is meant to be independent of (see `.claude/rules/integration-testing.md`).

Each seeding call was classified per-test as **Arrange** (converted) or **Act** (left in place):

| File | Converted (Arrange) | Left repository-based (Act) |
|------|---------------------|------------------------------|
| `ReadWriteRepositoryAsyncTests` | 9 — all Count/GetAll/GetPage/GetById/FindFirst read tests | — |
| `ReadWriteRepositoryDeleteByIdTests` | 3 — `Delete_by_id`, `GetById_with_onDbSet` ×2 | — |
| `UnitOfWorkRepositoryAsyncSQLiteInMemoryTests` | 3 — `UpdateAsync_entity`, `DeleteAsync_entity`, `Delete_entity` | 3 — `add_and_query` ×2 and `AddAsync_entity` (the add+commit IS the test) |
| `ReadWriteRepositoryAsyncAuditTests` | — | 2 — the class verifies the repository write path's own audit behaviour |

## Checklist before requesting a review

- [x] I have performed a self-review of my code
- [x] I have added thorough tests. _(No new tests — this refactors existing fixture setup; one vacuous test is now genuinely exercised.)_
- [x] I have updated documentation. _(Code comments updated; no public API or markdown docs affected.)_
- [x] If applicable, I have updated the sample application _(N/A — test-only change.)_

## :triangular_ruler: Design Decisions

- **`ReadWriteRepositoryAsyncAuditTests` left entirely repository-based.** The class exists to verify the audit behaviour of the repository write path. `Add_..._created_time`'s add+commit is the operation under test; `Update_..._modified_time`'s first assertion (`blog.ModifiedTime.Should().BeNull()`) checks that a *repository* Add leaves `ModifiedTime` unset — a separate-context seed would make that assertion vacuous. Both kept, with comments.
- **UoW add/query tests left repository-based.** `RepositoryAsync_and_UnitOfWorkAsync_add_and_query...` and `AddAsync_entity` exist to prove entities added through a UoW repository are persisted; the seeding call IS the Act.
- **`UpdateAsync_entity` uses fetch-modify-update.** Updating a freshly-constructed partial `Blog` made `ReadWriteRepositoryAsync.UpdateAsync` (via `CurrentValues.SetValues`) blank `CreatedTime`. Rather than mask that with an exclusion, the test loads-modifies-updates so the column is preserved. The broader library behaviour is tracked separately in #88.
- **Helper delegation direction.** `AddTestBlogEntities`: the `DbContext` overload holds the seed logic and does not dispose; the `Func<DbContext>` overload creates, `await using`-disposes, and delegates to it — never the reverse.

## Testing

- Full integration-test project: **85 passed, 0 failed**.
- Codex review of the diff: no regressions.
- All 14 PR review threads (CodeRabbit/codereviewbot, gemini-code-assist, codeant-ai) triaged and resolved: 9 false positives disproved with evidence, 4 suggestions declined with reasoning, 1 genuine issue (`CreatedTime` masking) fixed in `4e9acca`.
- Pre-existing analyzer warnings remain only in `src/` library code (carried in by the #75 merge, unrelated to test seeding) — out of scope; no new warnings introduced by these changes.

## Related

- Closes #85
- Follow-up: #88 (`UpdateAsync` blanks unsupplied columns on partial detached update)
- Builds on #75

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Tests**
  * Improved integration test reliability by seeding via separate DB contexts.
  * Refined assertions to avoid false positives and better reflect navigation property behavior.
  * Added helper seeding methods for test entities and clarified test setup/Act expectations with inline comments.
* **Chores**
  * Adjusted test file pattern in editor configuration to apply settings consistently.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/mrploch/ploch-data/pull/87?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->