### PR TITLE
fix(deps): Override vulnerable SQLitePCLRaw with patched 3.0.3 bundle

### DIFF
--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -11,8 +11,11 @@
     <PackageVersion Include="Microsoft.EntityFrameworkCore.Design" Version="10.0.5" />
     <PackageVersion Include="Microsoft.EntityFrameworkCore.Tools" Version="10.0.5" />
     <!-- Direct override: every SQLitePCLRaw.lib.e_sqlite3 2.1.x (<= 2.1.11) carries a
-         high-severity SQLite vulnerability (GHSA-2m69-gcr7-jv3q) and EF Core still floors
-         at the vulnerable 2.1.11. The 3.x bundle ships the patched native SQLite. -->
+         high-severity SQLite vulnerability (GHSA-2m69-gcr7-jv3q) and EF Core still pins
+         the vulnerable 2.1.11. The 3.x bundle ships the patched native SQLite.
+         Remove this version and the direct PackageReference in Data.EFCore.SqLite once
+         Microsoft.EntityFrameworkCore.Sqlite references SQLitePCLRaw 3.x itself; verify
+         with a vulnerable-packages scan (dotnet list package, vulnerable + transitive). -->
     <PackageVersion Include="SQLitePCLRaw.bundle_e_sqlite3" Version="3.0.3" />
     <PackageVersion Include="System.Net.Http" Version="4.3.4" />
   </ItemGroup>

--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -10,6 +10,10 @@
     <PackageVersion Include="Microsoft.Data.SqlClient" Version="6.1.4" />
     <PackageVersion Include="Microsoft.EntityFrameworkCore.Design" Version="10.0.5" />
     <PackageVersion Include="Microsoft.EntityFrameworkCore.Tools" Version="10.0.5" />
+    <!-- Direct override: every SQLitePCLRaw.lib.e_sqlite3 2.1.x (<= 2.1.11) carries a
+         high-severity SQLite vulnerability (GHSA-2m69-gcr7-jv3q) and EF Core still floors
+         at the vulnerable 2.1.11. The 3.x bundle ships the patched native SQLite. -->
+    <PackageVersion Include="SQLitePCLRaw.bundle_e_sqlite3" Version="3.0.3" />
     <PackageVersion Include="System.Net.Http" Version="4.3.4" />
   </ItemGroup>
   <Import Project="../mrploch-development/dependencies/Ploch.Packages.props" />

--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -1,5 +1,15 @@
 # Release Notes
 
+## Unreleased
+
+### Security
+
+- **Fixed vulnerable transitive `SQLitePCLRaw.lib.e_sqlite3` (high severity,
+  [GHSA-2m69-gcr7-jv3q](https://github.com/advisories/GHSA-2m69-gcr7-jv3q))** — `Ploch.Data.EFCore.SqLite`
+  now references `SQLitePCLRaw.bundle_e_sqlite3` 3.0.3 directly, overriding the vulnerable 2.1.x
+  version that EF Core still pulls transitively. All packages depending on the SQLite provider
+  resolve the patched native SQLite library. See `change-log/issue-91-vulnerable-sqlitepclraw.md`. (#91)
+
 ## v2.1 — NBGV Versioning and Release Pipeline
 
 ### Overview

--- a/change-log/issue-91-vulnerable-sqlitepclraw.md
+++ b/change-log/issue-91-vulnerable-sqlitepclraw.md
@@ -1,0 +1,27 @@
+# Context
+
+`SQLitePCLRaw.lib.e_sqlite3` versions `<= 2.1.11` carry a high-severity vulnerability in the bundled
+native SQLite library ([GHSA-2m69-gcr7-jv3q](https://github.com/advisories/GHSA-2m69-gcr7-jv3q)).
+Every Ploch.Data package that transitively pulls the SQLite provider (via
+`Microsoft.EntityFrameworkCore.Sqlite`) shipped the vulnerable native library, because EF Core —
+including the latest 10.0.x patch releases — still floors the dependency at the vulnerable `2.1.11`.
+
+# Change
+
+- Added a direct top-level `SQLitePCLRaw.bundle_e_sqlite3` **3.0.3** reference to
+  `Ploch.Data.EFCore.SqLite`. The 3.x bundle ships the patched native SQLite
+  (via `SourceGear.sqlite3` 3.50.4.5) and wins transitive version resolution, so all dependent
+  projects and published packages now resolve the fixed native library.
+- Central version added to `Directory.Packages.props` (and the SampleApp's standalone
+  `Directory.Packages.props`).
+- The SampleApp projects that consume published Ploch.Data packages carry the same direct
+  override until they consume a package version that includes this fix.
+
+# Impact
+
+- `dotnet list package --vulnerable --include-transitive` no longer reports any vulnerable
+  packages in Ploch.Data projects.
+- No API changes. Consumers get `SQLitePCLRaw.bundle_e_sqlite3 >= 3.0.3` transitively from
+  `Ploch.Data.EFCore.SqLite`.
+
+Refs: #91

--- a/change-log/issue-91-vulnerable-sqlitepclraw.md
+++ b/change-log/issue-91-vulnerable-sqlitepclraw.md
@@ -4,7 +4,7 @@
 native SQLite library ([GHSA-2m69-gcr7-jv3q](https://github.com/advisories/GHSA-2m69-gcr7-jv3q)).
 Every Ploch.Data package that transitively pulls the SQLite provider (via
 `Microsoft.EntityFrameworkCore.Sqlite`) shipped the vulnerable native library, because EF Core —
-including the latest 10.0.x patch releases — still floors the dependency at the vulnerable `2.1.11`.
+including the latest 10.0.x patch releases — still pins the dependency at the vulnerable `2.1.11`.
 
 # Change
 

--- a/samples/SampleApp/Directory.Packages.props
+++ b/samples/SampleApp/Directory.Packages.props
@@ -31,6 +31,9 @@
     <PackageVersion Include="Microsoft.EntityFrameworkCore.Tools" Version="10.0.5" />
     <PackageVersion Include="Microsoft.EntityFrameworkCore.Sqlite" Version="10.0.5" />
     <PackageVersion Include="Microsoft.EntityFrameworkCore.SqlServer" Version="10.0.5" />
+    <!-- Direct override: SQLitePCLRaw.lib.e_sqlite3 <= 2.1.11 carries a high-severity
+         SQLite vulnerability (GHSA-2m69-gcr7-jv3q); EF Core still floors at 2.1.11. -->
+    <PackageVersion Include="SQLitePCLRaw.bundle_e_sqlite3" Version="3.0.3" />
   </ItemGroup>
 
   <ItemGroup Label="Microsoft Extensions">

--- a/samples/SampleApp/Directory.Packages.props
+++ b/samples/SampleApp/Directory.Packages.props
@@ -32,7 +32,9 @@
     <PackageVersion Include="Microsoft.EntityFrameworkCore.Sqlite" Version="10.0.5" />
     <PackageVersion Include="Microsoft.EntityFrameworkCore.SqlServer" Version="10.0.5" />
     <!-- Direct override: SQLitePCLRaw.lib.e_sqlite3 <= 2.1.11 carries a high-severity
-         SQLite vulnerability (GHSA-2m69-gcr7-jv3q); EF Core still floors at 2.1.11. -->
+         SQLite vulnerability (GHSA-2m69-gcr7-jv3q); EF Core still pins the vulnerable
+         2.1.11. Remove this version and the direct PackageReferences in the sample
+         projects once the consumed Ploch.Data package versions carry the fix. -->
     <PackageVersion Include="SQLitePCLRaw.bundle_e_sqlite3" Version="3.0.3" />
   </ItemGroup>
 

--- a/samples/SampleApp/src/ConsoleApp/Ploch.Data.SampleApp.ConsoleApp.csproj
+++ b/samples/SampleApp/src/ConsoleApp/Ploch.Data.SampleApp.ConsoleApp.csproj
@@ -8,6 +8,10 @@
   <ItemGroup>
     <PackageReference Include="Microsoft.Extensions.Hosting" />
     <PackageReference Include="Ploch.Data.GenericRepository.EFCore.SqLite" />
+    <!-- Overrides the vulnerable SQLitePCLRaw 2.1.x pulled transitively through the
+         published Ploch.Data packages (GHSA-2m69-gcr7-jv3q). Remove once the consumed
+         package versions carry the override themselves. -->
+    <PackageReference Include="SQLitePCLRaw.bundle_e_sqlite3" />
   </ItemGroup>
   <ItemGroup>
     <ProjectReference Include="..\Data\Ploch.Data.SampleApp.Data.csproj" />

--- a/samples/SampleApp/src/Data.SQLite/Ploch.Data.SampleApp.Data.SQLite.csproj
+++ b/samples/SampleApp/src/Data.SQLite/Ploch.Data.SampleApp.Data.SQLite.csproj
@@ -7,6 +7,10 @@
   <ItemGroup>
     <PackageReference Include="Ploch.Data.EFCore.SqLite" />
     <PackageReference Include="Ploch.Data.EFCore" />
+    <!-- Overrides the vulnerable SQLitePCLRaw 2.1.x pulled transitively through the
+         published Ploch.Data packages (GHSA-2m69-gcr7-jv3q). Remove once the consumed
+         Ploch.Data.EFCore.SqLite package version carries the override itself. -->
+    <PackageReference Include="SQLitePCLRaw.bundle_e_sqlite3" />
   </ItemGroup>
   <ItemGroup>
     <ProjectReference Include="..\Data\Ploch.Data.SampleApp.Data.csproj" />

--- a/samples/SampleApp/tests/IntegrationTests/Ploch.Data.SampleApp.IntegrationTests.csproj
+++ b/samples/SampleApp/tests/IntegrationTests/Ploch.Data.SampleApp.IntegrationTests.csproj
@@ -20,6 +20,10 @@
   </ItemGroup>
   <ItemGroup>
     <PackageReference Include="Ploch.Data.GenericRepository.EFCore.IntegrationTesting" />
+    <!-- Overrides the vulnerable SQLitePCLRaw 2.1.x pulled transitively through the
+         published Ploch.Data packages (GHSA-2m69-gcr7-jv3q). Remove once the consumed
+         package versions carry the override themselves. -->
+    <PackageReference Include="SQLitePCLRaw.bundle_e_sqlite3" />
   </ItemGroup>
   <ItemGroup>
     <ProjectReference Include="..\..\src\Data\Ploch.Data.SampleApp.Data.csproj" />

--- a/src/Data.EFCore.SqLite/Ploch.Data.EFCore.SqLite.csproj
+++ b/src/Data.EFCore.SqLite/Ploch.Data.EFCore.SqLite.csproj
@@ -9,6 +9,9 @@
     <PackageReference Include="Microsoft.EntityFrameworkCore" />
     <PackageReference Include="Microsoft.EntityFrameworkCore.Sqlite" />
     <PackageReference Include="Microsoft.Extensions.DependencyInjection.Abstractions" />
+    <!-- Overrides the vulnerable SQLitePCLRaw 2.1.x pulled transitively by
+         Microsoft.EntityFrameworkCore.Sqlite (GHSA-2m69-gcr7-jv3q). -->
+    <PackageReference Include="SQLitePCLRaw.bundle_e_sqlite3" />
   </ItemGroup>
 
   <ItemGroup>


### PR DESCRIPTION
## **User description**
# Pull Request Description

## Issue ticket number and link

Closes #91

## Pull Request Changes Summary

### :beetle: Fixes

- **Security:** eliminated the high-severity vulnerability [GHSA-2m69-gcr7-jv3q](https://github.com/advisories/GHSA-2m69-gcr7-jv3q) carried by the transitive `SQLitePCLRaw.lib.e_sqlite3` (versions 2.1.6 / 2.1.11) that flowed into shipping packages and the SampleApp.

### :book: Docs

- `RELEASE_NOTES.md` — added an *Unreleased → Security* entry.
- `change-log/issue-91-vulnerable-sqlitepclraw.md` — full context, change, and impact record.

## Describe your changes

Every `SQLitePCLRaw.lib.e_sqlite3` 2.1.x release (`<= 2.1.11`) bundles a vulnerable native SQLite, and there is **no patched 2.1.x** — the fix line is the 3.x series (`SQLitePCLRaw.bundle_e_sqlite3` 3.0.3 → `SourceGear.sqlite3` 3.50.4.5). EF Core, including the latest 10.0.9, still floors the transitive dependency at the vulnerable `2.1.11`, so a plain EF bump cannot fix this.

The change adds a direct top-level `SQLitePCLRaw.bundle_e_sqlite3` reference (centrally versioned at **3.0.3**):

- `src/Data.EFCore.SqLite/Ploch.Data.EFCore.SqLite.csproj` — the root of the SQLite chain; the override wins transitive resolution and flows to every dependent project **and to consumers of the published package**.
- `Directory.Packages.props` — central version with a why-comment.
- SampleApp (`Directory.Packages.props`, `Data.SQLite`, `ConsoleApp`, `IntegrationTests` csprojs) — the SampleApp consumes *published* Ploch.Data packages, which still pull the old bundle; the same override applies there, with comments noting it can be removed once the consumed package versions carry the fix themselves.

## Checklist before requesting a review

- [x] I have performed a self-review of my code
- [x] I have added thorough tests. *(No code changes — dependency override only; validated by the full existing suite, incl. all SQLite integration tests.)*
- [x] I have updated documentation.
- [x] If applicable, I have updated the sample application

## :triangular_ruler: Design Decisions

- **Direct reference over `CentralPackageTransitivePinningEnabled`** — transitive pinning would pin *every* centrally-versioned package and risks NU1109 downgrade errors on the net8.0 TFM (EF 8.0.25 overrides); a single explicit reference is surgical and self-documenting.
- **Override in the shipping library, not just tests** — `Ploch.Data.EFCore.SqLite` declaring `bundle_e_sqlite3 >= 3.0.3` means consumers automatically get the patched native SQLite without any action on their side.
- **SampleApp overrides marked as temporary** — each carries a comment to remove it once the consumed package versions include the fix.

## Testing

- `dotnet list Ploch.Data.slnx package --vulnerable --include-transitive` → **zero** vulnerable packages in Ploch.Data projects (remaining findings are in `Ploch.TestingSupport.XUnit3.*`, which live in ploch-common — reported separately).
- Full Release build: **0 errors**, warning profile byte-identical to `main` except **NU1903 128 → 0** (pre-existing analyzer warnings tracked by #90, NU1603 by #68).
- Full test suite: **239 passed / 1 failed** — the single failure is a pre-existing local cross-repo assembly-version skew, reproduced identically on `main` without this change, and tracked by #95.
- SampleApp ConsoleApp ran end-to-end on the patched native library: `=== Sample Application Complete ===`, exit 0.

<div id='description'>
<a href="https://bito.ai#summarystart"></a><h3>Summary by Bito</h3><ul><li>Mitigated a high-severity SQLite vulnerability (GHSA-2m69-gcr7-jv3q) by forcing an upgrade to SQLitePCLRaw.bundle_e_sqlite3 3.0.3.</li>
<li>Added a direct package reference to SQLitePCLRaw.bundle_e_sqlite3 in Ploch.Data.EFCore.SqLite to override the vulnerable transitive dependency pulled by EF Core.</li>
<li>Updated Directory.Packages.props files to centralize the 3.0.3 version override.</li>
<li>Applied temporary package overrides in SampleApp projects to ensure the fix is active until updated Ploch.Data packages are consumed.</li>
<li>Documented the security fix in RELEASE_NOTES.md and a new change-log file.</li>
</ul></div>


___

## **CodeAnt-AI Description**
**Override the vulnerable SQLite package used by EF Core**

### What Changed
- Adds a direct `SQLitePCLRaw.bundle_e_sqlite3` 3.0.3 reference so projects use the patched SQLite library instead of the vulnerable 2.1.x version pulled in by EF Core
- Applies the same override to the sample app projects that consume published packages, so the fix is present there too
- Updates release notes and the issue log with the security fix details

### Impact
`✅ Fewer vulnerable package findings`
`✅ Patched SQLite in shipped apps`
`✅ Clearer security release notes`
<details><summary><strong>💡 Usage Guide</strong></summary>

### Checking Your Pull Request
Every time you make a pull request, our system automatically looks through it. We check for security issues, mistakes in how you're setting up your infrastructure, and common code problems. We do this to make sure your changes are solid and won't cause any trouble later.

### Talking to CodeAnt AI
Got a question or need a hand with something in your pull request? You can easily get in touch with CodeAnt AI right here. Just type the following in a comment on your pull request, and replace "Your question here" with whatever you want to ask:
<pre>
<code>@codeant-ai ask: Your question here</code>
</pre>
This lets you have a chat with CodeAnt AI about your pull request, making it easier to understand and improve your code.

#### Example
<pre>
<code>@codeant-ai ask: Can you suggest a safer alternative to storing this secret?</code>
</pre>

### Preserve Org Learnings with CodeAnt
You can record team preferences so CodeAnt AI applies them in future reviews. Reply directly to the specific CodeAnt AI suggestion (in the same thread) and replace "Your feedback here" with your input:
<pre>
<code>@codeant-ai: Your feedback here</code>
</pre>
This helps CodeAnt AI learn and adapt to your team's coding style and standards.

#### Example
<pre>
<code>@codeant-ai: Do not flag unused imports.</code>
</pre>

### Retrigger review
Ask CodeAnt AI to review the PR again, by typing:
<pre>
<code>@codeant-ai: review</code>
</pre>

### Check Your Repository Health
To analyze the health of your code repository, visit our dashboard at [https://app.codeant.ai](https://app.codeant.ai). This tool helps you identify potential issues and areas for improvement in your codebase, ensuring your repository maintains high standards of code health.

</details>


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Security**
  * Updated the bundled SQLite component to version 3.0.3, addressing a high-severity vulnerability in older versions.
  * Applied the security update across the SQLite integration and sample applications.
* **Documentation**
  * Added unreleased release notes and a changelog entry describing the vulnerability remediation.
  * Confirmed that vulnerability scanning no longer reports the affected package.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->