### PR TITLE
refactor(solution): Resolve all 31 analyzer warnings across src and tests

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -157,7 +157,9 @@ csharp_style_prefer_utf8_string_literals = true:suggestion
 csharp_style_throw_expression = true:suggestion
 
 csharp_style_unused_value_assignment_preference = discard_variable:suggestion
-csharp_style_unused_value_expression_statement_preference = discard_variable:suggestion
+# IDE0058 activation is deliberately kept at 'silent' (the .NET default) — see the
+# dotnet_diagnostic.IDE0058 entry near the end of this file for the full rationale.
+csharp_style_unused_value_expression_statement_preference = discard_variable:silent
 
 csharp_style_var_elsewhere = true:warning
 csharp_style_var_for_built_in_types = true:warning
@@ -706,8 +708,14 @@ resharper_wrap_before_first_type_parameter_constraint = false
 # for the abstract base class + virtual ConfigureServices pattern used in test infrastructure.
 dotnet_diagnostic.CC0067.severity = none
 
-# Test project overrides
-[tests/**/*.cs]
-# IDE0058: Expression value is never used — test assertions and fluent API chains
-# intentionally discard return values.
+# IDE0058 ("Expression value is never used") is intentionally disabled repo-wide, matching
+# ploch-common and the Microsoft repos (dotnet/runtime and dotnet/aspnetcore leave it at its
+# 'silent' default; dotnet/roslyn disables it explicitly). Fluent/chained configuration APIs
+# (DbContextOptionsBuilder.UseSqlite, IServiceCollection.Add*, guard extensions) return values
+# that callers idiomatically ignore — 52 call sites across 13 src/ files fire this rule — and
+# IDE0058 offers no per-method/per-type exclusion (see dotnet/roslyn#57297, #47832 — open
+# feature requests). Per-call-site `_ = method()` discards are NOT an acceptable fix — they add
+# noise without intent. Was previously disabled only for tests/**, which let the build emit it
+# for src/, SonarCloud then imported the diagnostics as external issues on PR #99, and discards
+# were added in response (commit 6f2d38f); those discards have been removed.
 dotnet_diagnostic.IDE0058.severity = none

--- a/src/Data.EFCore.SqLite/SqLiteDbContextConfigurator.cs
+++ b/src/Data.EFCore.SqLite/SqLiteDbContextConfigurator.cs
@@ -48,11 +48,11 @@ public class SqLiteDbContextConfigurator(SqLiteConnectionOptions? options = null
                 _sharedConnection ??= CreateAndOpenConnection(connectionString);
             }
 
-            optionsBuilder.UseSqlite(_sharedConnection, dbContextOptionsAction);
+            _ = optionsBuilder.UseSqlite(_sharedConnection, dbContextOptionsAction);
         }
         else
         {
-            optionsBuilder.UseSqlite(connectionString, dbContextOptionsAction);
+            _ = optionsBuilder.UseSqlite(connectionString, dbContextOptionsAction);
         }
     }
 

--- a/src/Data.EFCore.SqLite/SqLiteDbContextConfigurator.cs
+++ b/src/Data.EFCore.SqLite/SqLiteDbContextConfigurator.cs
@@ -18,26 +18,17 @@ namespace Ploch.Data.EFCore.SqLite;
 ///         Implements <see cref="IDisposable" /> to release the shared connection when testing is complete.
 ///     </para>
 /// </remarks>
-public class SqLiteDbContextConfigurator : IDbContextConfigurator, IDisposable
+/// <param name="options">SqLite connection options. Defaults to <see cref="SqLiteConnectionOptions.InMemory" />.</param>
+/// <param name="dbContextOptionsAction">Action to execute on the SqLite DbContext options builder.</param>
+public class SqLiteDbContextConfigurator(SqLiteConnectionOptions? options = null, Action<SqliteDbContextOptionsBuilder>? dbContextOptionsAction = null)
+    : IDbContextConfigurator, IDisposable
 {
     // Cannot use the new System.Threading.Lock because we also target .NET 8.
     // ReSharper disable once ChangeFieldTypeToSystemThreadingLock
     private readonly object _connectionLock = new();
-    private readonly Action<SqliteDbContextOptionsBuilder>? _dbContextOptionsAction;
-    private readonly SqLiteConnectionOptions _options;
+    private readonly SqLiteConnectionOptions _options = options ?? SqLiteConnectionOptions.InMemory;
     private bool _disposed;
     private SqliteConnection? _sharedConnection;
-
-    /// <summary>
-    ///     Initializes a new instance of the <see cref="SqLiteDbContextConfigurator" /> class.
-    /// </summary>
-    /// <param name="options">SqLite connection options. Defaults to <see cref="SqLiteConnectionOptions.InMemory" />.</param>
-    /// <param name="dbContextOptionsAction">Action to execute on the SqLite DbContext options builder.</param>
-    public SqLiteDbContextConfigurator(SqLiteConnectionOptions? options = null, Action<SqliteDbContextOptionsBuilder>? dbContextOptionsAction = null)
-    {
-        _options = options ?? SqLiteConnectionOptions.InMemory;
-        _dbContextOptionsAction = dbContextOptionsAction;
-    }
 
     /// <summary>
     ///     Configures the given DbContextOptionsBuilder to use SQLite as the database provider.
@@ -57,11 +48,11 @@ public class SqLiteDbContextConfigurator : IDbContextConfigurator, IDisposable
                 _sharedConnection ??= CreateAndOpenConnection(connectionString);
             }
 
-            optionsBuilder.UseSqlite(_sharedConnection, _dbContextOptionsAction);
+            optionsBuilder.UseSqlite(_sharedConnection, dbContextOptionsAction);
         }
         else
         {
-            optionsBuilder.UseSqlite(connectionString, _dbContextOptionsAction);
+            optionsBuilder.UseSqlite(connectionString, dbContextOptionsAction);
         }
     }
 

--- a/src/Data.EFCore.SqLite/SqLiteDbContextConfigurator.cs
+++ b/src/Data.EFCore.SqLite/SqLiteDbContextConfigurator.cs
@@ -48,11 +48,11 @@ public class SqLiteDbContextConfigurator(SqLiteConnectionOptions? options = null
                 _sharedConnection ??= CreateAndOpenConnection(connectionString);
             }
 
-            _ = optionsBuilder.UseSqlite(_sharedConnection, dbContextOptionsAction);
+            optionsBuilder.UseSqlite(_sharedConnection, dbContextOptionsAction);
         }
         else
         {
-            _ = optionsBuilder.UseSqlite(connectionString, dbContextOptionsAction);
+            optionsBuilder.UseSqlite(connectionString, dbContextOptionsAction);
         }
     }
 

--- a/src/Data.EFCore.SqLite/SqLiteDbContextFactory.cs
+++ b/src/Data.EFCore.SqLite/SqLiteDbContextFactory.cs
@@ -1,4 +1,5 @@
-﻿using Microsoft.EntityFrameworkCore;
+﻿using System.Diagnostics.CodeAnalysis;
+using Microsoft.EntityFrameworkCore;
 using Microsoft.EntityFrameworkCore.Design;
 
 namespace Ploch.Data.EFCore.SqLite;
@@ -50,6 +51,9 @@ public abstract class SqLiteDbContextFactory<TDbContext, TFactory> : BaseDbConte
     ///     This property provides an implementation of <see cref="IDbContextCreationLifecycle" />,
     ///     which handles logic and behaviors specifically related to the initialization and setup of DbContext instances.
     /// </summary>
+    [SuppressMessage("Design",
+                     "CA1000:Do not declare static members on generic types",
+                     Justification = "Intended access is through concrete, non-generic derived factories, so callers never need to supply type arguments.")]
     public static IDbContextCreationLifecycle CreationLifecycle { get; } = new SqLiteDbContextCreationLifecycle();
 
     /// <summary>

--- a/src/Data.EFCore.SqlServer/SqlServerDbContextFactory.cs
+++ b/src/Data.EFCore.SqlServer/SqlServerDbContextFactory.cs
@@ -24,8 +24,8 @@ public abstract class SqlServerDbContextFactory<TDbContext, TFactory> : BaseDbCo
     /// </summary>
     /// <param name="dbContextCreator">Function to create an instance of DbContext.</param>
     /// <param name="connectionStringFunc">Function to return the connection string.</param>
-    protected SqlServerDbContextFactory(Func<DbContextOptions<TDbContext>, TDbContext> dbContextCreator, Func<string> connectionStringFunc) :
-        base(dbContextCreator, connectionStringFunc)
+    protected SqlServerDbContextFactory(Func<DbContextOptions<TDbContext>, TDbContext> dbContextCreator, Func<string> connectionStringFunc)
+        : base(dbContextCreator, connectionStringFunc)
     { }
 
     /// <summary>

--- a/src/Data.EFCore/CollectionStringSplitConverter.cs
+++ b/src/Data.EFCore/CollectionStringSplitConverter.cs
@@ -21,7 +21,7 @@ public class CollectionStringSplitConverter<TValue> : ValueConverter<ICollection
     /// </remarks>
     /// <param name="separator">Separator to be used when converting the collection to string.</param>
     /// <param name="convertNulls">Include null values in the conversion.</param>
-    /// <param name="mappingHints">Optional mapping hints to pass to the baase converter.</param>
+    /// <param name="mappingHints">Optional mapping hints to pass to the base converter.</param>
 #pragma warning disable SA1003 // Symbols should be spaced correctly - : should not appear at the end of the line - line is too long
     public CollectionStringSplitConverter(string separator = ",", bool convertNulls = true, ConverterMappingHints? mappingHints = null) :
 #pragma warning restore SA1003

--- a/src/Data.EFCore/DbContextExtensions.cs
+++ b/src/Data.EFCore/DbContextExtensions.cs
@@ -74,12 +74,18 @@ public static class DbContextExtensions
     /// <returns>
     ///     The value of the static property, or <see langword="default" /> when the stored value is <see langword="null" />.
     /// </returns>
+    /// <exception cref="ArgumentNullException">
+    ///     Thrown if <paramref name="type" /> or <paramref name="propertyName" /> is null.
+    /// </exception>
     /// <exception cref="InvalidOperationException">
     ///     Thrown when the property is not found on <paramref name="type" />, or when its value is not of type
     ///     <typeparamref name="TValue" />.
     /// </exception>
     public static TValue? GetStaticPropertyValue<TValue>(this Type type, string propertyName)
     {
+        ArgumentNullException.ThrowIfNull(type);
+        ArgumentNullException.ThrowIfNull(propertyName);
+
         // Accessing non-public static properties is the documented purpose of this helper —
         // callers explicitly opt in by naming the property (see GetStaticPropertyValueTests).
 #pragma warning disable S3011 // Reflection should not be used to increase accessibility

--- a/src/Data.EFCore/DbContextExtensions.cs
+++ b/src/Data.EFCore/DbContextExtensions.cs
@@ -1,5 +1,6 @@
 using System;
 using System.Linq;
+using System.Reflection;
 using Microsoft.EntityFrameworkCore;
 
 namespace Ploch.Data.EFCore;
@@ -35,23 +36,6 @@ public static class DbContextExtensions
         return context.Set(entityType);
     }
 
-    public static TValue? GetStaticPropertyValue<TValue>(this Type type, string propertyName)
-    {
-        var property = type.GetProperty(propertyName, System.Reflection.BindingFlags.Static | System.Reflection.BindingFlags.Public | System.Reflection.BindingFlags.NonPublic);
-
-        if (property == null)
-        {
-            throw new InvalidOperationException($"Static property '{propertyName}' was not found on type '{type}'.");
-        }
-
-        var valueObj = property.GetValue(null);
-
-        return valueObj switch
-               { null => default,
-                 TValue value => value,
-                 _ => throw new InvalidOperationException($"Static property {propertyName} in {type} is not of {typeof(TValue)} type") };
-    }
-
     /// <summary>
     ///     Retrieves an entity set dynamically for the specified entity type.
     /// </summary>
@@ -74,11 +58,45 @@ public static class DbContextExtensions
             throw new InvalidOperationException($"Entity type '{entityType.Name}' was not found in the context.");
         }
 
-        var setMethod = typeof(DbContext).GetMethods().First(m => m.Name == "Set" && m.ContainsGenericParameters && m.GetParameters().Length == 0);
+        var setMethod = typeof(DbContext).GetMethods().First(m => m.Name == nameof(Set) && m.ContainsGenericParameters && m.GetParameters().Length == 0);
 
         var genericSetMethod = setMethod.MakeGenericMethod(entityType);
 
         return (IQueryable<object>)genericSetMethod.Invoke(context, null)!;
+    }
+
+    /// <summary>
+    ///     Retrieves the value of a static property from the specified type.
+    /// </summary>
+    /// <typeparam name="TValue">The expected type of the property value.</typeparam>
+    /// <param name="type">The type that declares the static property.</param>
+    /// <param name="propertyName">The name of the static property. Public and non-public properties are supported.</param>
+    /// <returns>
+    ///     The value of the static property, or <see langword="default" /> when the stored value is <see langword="null" />.
+    /// </returns>
+    /// <exception cref="InvalidOperationException">
+    ///     Thrown when the property is not found on <paramref name="type" />, or when its value is not of type
+    ///     <typeparamref name="TValue" />.
+    /// </exception>
+    public static TValue? GetStaticPropertyValue<TValue>(this Type type, string propertyName)
+    {
+        // Accessing non-public static properties is the documented purpose of this helper —
+        // callers explicitly opt in by naming the property (see GetStaticPropertyValueTests).
+#pragma warning disable S3011 // Reflection should not be used to increase accessibility
+        var property = type.GetProperty(propertyName, BindingFlags.Static | BindingFlags.Public | BindingFlags.NonPublic);
+#pragma warning restore S3011
+
+        if (property == null)
+        {
+            throw new InvalidOperationException($"Static property '{propertyName}' was not found on type '{type}'.");
+        }
+
+        var valueObj = property.GetValue(null);
+
+        return valueObj switch
+               { null => default,
+                 TValue value => value,
+                 _ => throw new InvalidOperationException($"Static property {propertyName} in {type} is not of {typeof(TValue)} type") };
     }
 
     /// <summary>

--- a/src/Data.EFCore/DbContextExtensions.cs
+++ b/src/Data.EFCore/DbContextExtensions.cs
@@ -58,7 +58,7 @@ public static class DbContextExtensions
             throw new InvalidOperationException($"Entity type '{entityType.Name}' was not found in the context.");
         }
 
-        var setMethod = typeof(DbContext).GetMethods().First(m => m.Name == nameof(Set) && m.ContainsGenericParameters && m.GetParameters().Length == 0);
+        var setMethod = typeof(DbContext).GetMethods().First(m => m.Name == nameof(DbContext.Set) && m.ContainsGenericParameters && m.GetParameters().Length == 0);
 
         var genericSetMethod = setMethod.MakeGenericMethod(entityType);
 

--- a/src/Data.GenericRepository/Data.GenericRepository.EFCore/ReadRepositoryAsync.cs
+++ b/src/Data.GenericRepository/Data.GenericRepository.EFCore/ReadRepositoryAsync.cs
@@ -45,7 +45,7 @@ public class ReadRepositoryAsync<TEntity>(DbContext dbContext, IAuditEntityHandl
 
         foreach (var entity in result)
         {
-            AuditEntityHandler.HandleAccess(entity);
+            _ = AuditEntityHandler.HandleAccess(entity);
         }
 
         return result;
@@ -96,7 +96,7 @@ public class ReadRepositoryAsync<TEntity, TId>(DbContext dbContext, IAuditEntity
 
         if (result != null)
         {
-            AuditEntityHandler.HandleAccess(result);
+            _ = AuditEntityHandler.HandleAccess(result);
         }
 
         return result;

--- a/src/Data.GenericRepository/Data.GenericRepository.EFCore/ReadRepositoryAsync.cs
+++ b/src/Data.GenericRepository/Data.GenericRepository.EFCore/ReadRepositoryAsync.cs
@@ -20,7 +20,7 @@ public class ReadRepositoryAsync<TEntity>(DbContext dbContext, IAuditEntityHandl
     /// <summary>
     ///     Gets the handler used to record entity access for auditing purposes.
     /// </summary>
-    protected IAuditEntityHandler AuditEntityHandler { get; } = auditEntityHandler;
+    protected IAuditEntityHandler AuditEntityHandler { get; } = auditEntityHandler ?? throw new ArgumentNullException(nameof(auditEntityHandler));
 
     /// <inheritdoc />
     public async Task<TEntity?> GetByIdAsync(object[] keyValues, CancellationToken cancellationToken = default) =>

--- a/src/Data.GenericRepository/Data.GenericRepository.EFCore/ReadRepositoryAsync.cs
+++ b/src/Data.GenericRepository/Data.GenericRepository.EFCore/ReadRepositoryAsync.cs
@@ -17,6 +17,11 @@ namespace Ploch.Data.GenericRepository.EFCore;
 public class ReadRepositoryAsync<TEntity>(DbContext dbContext, IAuditEntityHandler auditEntityHandler)
     : QueryableRepository<TEntity>(dbContext), IReadRepositoryAsync<TEntity> where TEntity : class
 {
+    /// <summary>
+    ///     Gets the handler used to record entity access for auditing purposes.
+    /// </summary>
+    protected IAuditEntityHandler AuditEntityHandler { get; } = auditEntityHandler;
+
     /// <inheritdoc />
     public async Task<TEntity?> GetByIdAsync(object[] keyValues, CancellationToken cancellationToken = default) =>
         await DbSet.FindAsync(keyValues, cancellationToken).ConfigureAwait(false);
@@ -40,7 +45,7 @@ public class ReadRepositoryAsync<TEntity>(DbContext dbContext, IAuditEntityHandl
 
         foreach (var entity in result)
         {
-            auditEntityHandler.HandleAccess(entity);
+            AuditEntityHandler.HandleAccess(entity);
         }
 
         return result;
@@ -91,7 +96,7 @@ public class ReadRepositoryAsync<TEntity, TId>(DbContext dbContext, IAuditEntity
 
         if (result != null)
         {
-            auditEntityHandler.HandleAccess(result);
+            AuditEntityHandler.HandleAccess(result);
         }
 
         return result;

--- a/src/Data.GenericRepository/Data.GenericRepository.EFCore/ReadRepositoryAsync.cs
+++ b/src/Data.GenericRepository/Data.GenericRepository.EFCore/ReadRepositoryAsync.cs
@@ -45,7 +45,7 @@ public class ReadRepositoryAsync<TEntity>(DbContext dbContext, IAuditEntityHandl
 
         foreach (var entity in result)
         {
-            _ = AuditEntityHandler.HandleAccess(entity);
+            AuditEntityHandler.HandleAccess(entity);
         }
 
         return result;
@@ -96,7 +96,7 @@ public class ReadRepositoryAsync<TEntity, TId>(DbContext dbContext, IAuditEntity
 
         if (result != null)
         {
-            _ = AuditEntityHandler.HandleAccess(result);
+            AuditEntityHandler.HandleAccess(result);
         }
 
         return result;

--- a/src/Data.GenericRepository/Data.GenericRepository/RepositoriesConfiguration.cs
+++ b/src/Data.GenericRepository/Data.GenericRepository/RepositoriesConfiguration.cs
@@ -17,5 +17,5 @@ public class RepositoriesConfiguration
     ///     When enabled, the repository will track when entities are accessed or queried.
     /// </summary>
     /// <value><c>true</c> to enable access auditing; otherwise, <c>false</c>. Default is <c>false</c>.</value>
-    public bool AuditAccess { get; set; } = false;
+    public bool AuditAccess { get; set; }
 }

--- a/tests/.editorconfig
+++ b/tests/.editorconfig
@@ -30,6 +30,9 @@ dotnet_diagnostic.IDE0052.severity = warning # Remove unused private members
 dotnet_diagnostic.s4487.severity = none # Unread "private" fields should be removed
 dotnet_diagnostic.s4261.severity = none # Methods that return Task should end with "Async" - not applicable to xUnit test methods whose names follow the Method_should_do_X convention
 
+# Threading analyzers
+dotnet_diagnostic.VSTHRD200.severity = none # Use "Async" suffix for awaitable methods - not applicable to xUnit test methods whose names follow the Method_should_do_X convention (same rationale as s4261 above)
+
 # StyleCop settings
 dotnet_diagnostic.sa0001.severity = none # XML comment analysis is disabled due to project configuration
 dotnet_diagnostic.sa1402.severity = none # File may only contain a single type

--- a/tests/Data.EFCore.SqLite.Tests/SqLiteDbContextFactoryTests.cs
+++ b/tests/Data.EFCore.SqLite.Tests/SqLiteDbContextFactoryTests.cs
@@ -155,13 +155,11 @@ public class SqLiteDbContextFactoryTests
         }
     }
 
-    private sealed class LifecycleIntegrationTestFactory : SqLiteDbContextFactory<LifecycleIntegrationTestDbContext, LifecycleIntegrationTestFactory>
-    {
-        public LifecycleIntegrationTestFactory(Func<DbContextOptions<LifecycleIntegrationTestDbContext>, LifecycleIntegrationTestDbContext> dbContextCreator,
-                                               Func<string> connectionStringFunc)
-            : base(dbContextCreator, connectionStringFunc)
-        { }
-    }
+    private sealed class LifecycleIntegrationTestFactory(
+        Func<DbContextOptions<LifecycleIntegrationTestDbContext>, LifecycleIntegrationTestDbContext> dbContextCreator,
+        Func<string> connectionStringFunc)
+        : SqLiteDbContextFactory<LifecycleIntegrationTestDbContext, LifecycleIntegrationTestFactory>(dbContextCreator, connectionStringFunc)
+    { }
 
     private sealed class TestSqLiteDbContextFactory : SqLiteDbContextFactory<TestDbContext, TestSqLiteDbContextFactory>
     {

--- a/tests/Data.EFCore.SqlServer.Tests/ConnectionStringBuilderTests.cs
+++ b/tests/Data.EFCore.SqlServer.Tests/ConnectionStringBuilderTests.cs
@@ -6,13 +6,15 @@ namespace Ploch.Data.EFCore.SqlServer.Tests;
 public class ConnectionStringBuilderTests
 {
     [Fact]
-    public void MyMethod()
+    public void SqlConnectionStringBuilder_should_build_expected_connection_string()
     {
-        var builder = new SqlConnectionStringBuilder();
-        builder.DataSource = "localhost";
-        builder.InitialCatalog = "Ploch.Lists";
-        builder.TrustServerCertificate = true;
-        builder.IntegratedSecurity = true;
+        var builder = new SqlConnectionStringBuilder
+        {
+            DataSource = "localhost",
+            InitialCatalog = "Ploch.Lists",
+            TrustServerCertificate = true,
+            IntegratedSecurity = true
+        };
         var connectionString = builder.ToString();
         connectionString.Should().Be("Data Source=localhost;Initial Catalog=Ploch.Lists;Integrated Security=True;Trust Server Certificate=True");
     }

--- a/tests/Data.EFCore.SqlServer.Tests/SqlServerTests.cs
+++ b/tests/Data.EFCore.SqlServer.Tests/SqlServerTests.cs
@@ -9,9 +9,6 @@ public class SqlServerTests : DataIntegrationTest<TestDbContext>
     public SqlServerTests() : base(new SqlServerDbContextConfigurator(builder =>
         {
             builder.DataSource = "localhost,1401";
-
-            // TODO: How to rename the database? When DB name is provided here but it doesn't yet exist, the connection faile
-            //builder.InitialCatalog = $"Ploch{Guid.NewGuid()}";
             builder.UserID = "sa";
             builder.Password = "P@ssw0rd";
             builder.TrustServerCertificate = true;

--- a/tests/Data.EFCore.Tests/CollectionStringSplitConverterTests.cs
+++ b/tests/Data.EFCore.Tests/CollectionStringSplitConverterTests.cs
@@ -1,4 +1,5 @@
 using System.ComponentModel.DataAnnotations;
+using System.Globalization;
 using System.Linq.Expressions;
 using FluentAssertions;
 using Microsoft.EntityFrameworkCore;
@@ -10,12 +11,6 @@ namespace Ploch.Data.EFCore.Tests;
 
 public class CollectionStringSplitConverterTests : DataIntegrationTest<ConverterTestDbContext>
 {
-    public static IEnumerable<object[]> Data => new List<object[]>
-                                                { new object[] { 1, 2, 3 },
-                                                  new object[] { -4, -6, -10 },
-                                                  new object[] { -2, 2, 0 },
-                                                  new object[] { int.MinValue, -1, int.MaxValue } };
-
     [Theory]
     [AutoMockData]
     public void CollectionStringSplitConverter_should_convert_to_and_from_string_list(List<string> firstList, List<string> secondList)
@@ -51,7 +46,7 @@ public class CollectionStringSplitConverterTests : DataIntegrationTest<Converter
                                   (e, v) => e.IntCollection = v,
                                   firstIntList,
                                   secondIntList,
-                                  t => ((string)(object)t.IntCollection).Contains(secondIntList[1].ToString()));
+                                  t => ((string)(object)t.IntCollection).Contains(secondIntList[1].ToString(CultureInfo.CurrentCulture)));
     }
 
     [Theory]
@@ -62,7 +57,7 @@ public class CollectionStringSplitConverterTests : DataIntegrationTest<Converter
                                   (e, v) => e.DatesCollection = v,
                                   firstDateTimeList,
                                   secondDateTimeList,
-                                  t => ((string)(object)t.DatesCollection).Contains(Uri.EscapeDataString(secondDateTimeList[1].ToString())));
+                                  t => ((string)(object)t.DatesCollection).Contains(Uri.EscapeDataString(secondDateTimeList[1].ToString(CultureInfo.CurrentCulture))));
     }
 
     private void ValidateConverterEntities<TValue>(Func<ConverterTestEntity, ICollection<TValue>> entityPropertyFunc,
@@ -92,12 +87,12 @@ public class ConverterTestDbContext(DbContextOptions<ConverterTestDbContext> opt
 {
     public DbSet<ConverterTestEntity> TestEntities { get; set; } = null!;
 
-    protected override void OnModelCreating(ModelBuilder builder)
+    protected override void OnModelCreating(ModelBuilder modelBuilder)
     {
-        builder.Entity<ConverterTestEntity>().Property(e => e.StringCollection).HasConversion(new CollectionStringSplitConverter<string>());
-        builder.Entity<ConverterTestEntity>().Property(e => e.IntCollection).HasConversion(new CollectionStringSplitConverter<int>());
-        builder.Entity<ConverterTestEntity>().Property(e => e.DatesCollection).HasConversion(new CollectionStringSplitConverter<DateTime>());
-        base.OnModelCreating(builder);
+        modelBuilder.Entity<ConverterTestEntity>().Property(e => e.StringCollection).HasConversion(new CollectionStringSplitConverter<string>());
+        modelBuilder.Entity<ConverterTestEntity>().Property(e => e.IntCollection).HasConversion(new CollectionStringSplitConverter<int>());
+        modelBuilder.Entity<ConverterTestEntity>().Property(e => e.DatesCollection).HasConversion(new CollectionStringSplitConverter<DateTime>());
+        base.OnModelCreating(modelBuilder);
     }
 }
 

--- a/tests/Data.EFCore.Tests/CollectionStringSplitConverterTests.cs
+++ b/tests/Data.EFCore.Tests/CollectionStringSplitConverterTests.cs
@@ -42,11 +42,16 @@ public class CollectionStringSplitConverterTests : DataIntegrationTest<Converter
     [AutoMockData]
     public void CollectionStringSplitConverter_should_handle_int_list(List<int> firstIntList, List<int> secondIntList)
     {
+        // Search for the complete serialised list rather than a single element: a short digit
+        // substring such as "4" can also match inside another entity's values (e.g. "147"),
+        // which made this test fail intermittently depending on the generated data.
+        var serialisedSecondList = string.Join(",", secondIntList.Select(v => v.ToString(CultureInfo.CurrentCulture)));
+
         ValidateConverterEntities(e => e.IntCollection,
                                   (e, v) => e.IntCollection = v,
                                   firstIntList,
                                   secondIntList,
-                                  t => ((string)(object)t.IntCollection).Contains(secondIntList[1].ToString(CultureInfo.CurrentCulture)));
+                                  t => ((string)(object)t.IntCollection).Contains(serialisedSecondList));
     }
 
     [Theory]

--- a/tests/Data.EFCore.Tests/CollectionStringSplitConverterTests.cs
+++ b/tests/Data.EFCore.Tests/CollectionStringSplitConverterTests.cs
@@ -61,11 +61,16 @@ public class CollectionStringSplitConverterTests : DataIntegrationTest<Converter
     [AutoMockData]
     public void CollectionStringSplitConverter_should_handle_datetime_list(List<DateTime> firstDateTimeList, List<DateTime> secondDateTimeList)
     {
+        // Match the complete serialised list exactly, mirroring the converter's write format
+        // (Uri.EscapeDataString per element, string.Empty for default values) — searching for a
+        // single element could match the wrong entity if the generated lists share a value.
+        var serialisedSecondList = string.Join(",", secondDateTimeList.Select(v => v != default ? Uri.EscapeDataString(v.ToString(CultureInfo.CurrentCulture)) : string.Empty));
+
         ValidateConverterEntities(e => e.DatesCollection,
                                   (e, v) => e.DatesCollection = v,
                                   firstDateTimeList,
                                   secondDateTimeList,
-                                  t => ((string)(object)t.DatesCollection).Contains(Uri.EscapeDataString(secondDateTimeList[1].ToString(CultureInfo.CurrentCulture))));
+                                  t => (string)(object)t.DatesCollection == serialisedSecondList);
     }
 
     private void ValidateConverterEntities<TValue>(Func<ConverterTestEntity, ICollection<TValue>> entityPropertyFunc,

--- a/tests/Data.EFCore.Tests/CollectionStringSplitConverterTests.cs
+++ b/tests/Data.EFCore.Tests/CollectionStringSplitConverterTests.cs
@@ -45,7 +45,10 @@ public class CollectionStringSplitConverterTests : DataIntegrationTest<Converter
         // Search for the complete serialised list rather than a single element: a short digit
         // substring such as "4" can also match inside another entity's values (e.g. "147"),
         // which made this test fail intermittently depending on the generated data.
-        var serialisedSecondList = string.Join(",", secondIntList.Select(v => v.ToString(CultureInfo.CurrentCulture)));
+        // Mirror the converter's write format exactly (Uri.EscapeDataString per element,
+        // string.Empty for default values) so the expected string cannot diverge from the
+        // stored value regardless of the generated data.
+        var serialisedSecondList = string.Join(",", secondIntList.Select(v => v != 0 ? Uri.EscapeDataString(v.ToString(CultureInfo.CurrentCulture)) : string.Empty));
 
         ValidateConverterEntities(e => e.IntCollection,
                                   (e, v) => e.IntCollection = v,

--- a/tests/Data.EFCore.Tests/CollectionStringSplitConverterTests.cs
+++ b/tests/Data.EFCore.Tests/CollectionStringSplitConverterTests.cs
@@ -19,8 +19,13 @@ public class CollectionStringSplitConverterTests : DataIntegrationTest<Converter
         DbContext.TestEntities.Add(new() { StringCollection = secondList });
         DbContext.SaveChanges();
 
+        // Match the complete serialised list exactly, mirroring the converter's write format
+        // (Uri.EscapeDataString per element, string.Empty for default values) — searching for a
+        // single element could match the wrong entity if the generated lists share a value.
+        var serialisedSecondList = string.Join(",", secondList.Select(v => v != null ? Uri.EscapeDataString(v) : string.Empty));
+
         var entity = DbContext.TestEntities.Skip(1).First();
-        var queriedEntity = DbContext.TestEntities.FirstOrDefault(t => ((string)(object)t.StringCollection).Contains(secondList[1]));
+        var queriedEntity = DbContext.TestEntities.FirstOrDefault(t => (string)(object)t.StringCollection == serialisedSecondList);
 
         entity.Should().BeEquivalentTo(queriedEntity);
         entity.StringCollection.Should().HaveCount(secondList.Count);
@@ -31,11 +36,16 @@ public class CollectionStringSplitConverterTests : DataIntegrationTest<Converter
     [AutoMockData]
     public void CollectionStringSplitConverter_should_handle_string_list(List<string> firstStringList, List<string> secondStringList)
     {
+        // Match the complete serialised list exactly, mirroring the converter's write format
+        // (Uri.EscapeDataString per element, string.Empty for default values) — searching for a
+        // single element could match the wrong entity if the generated lists share a value.
+        var serialisedSecondList = string.Join(",", secondStringList.Select(v => v != null ? Uri.EscapeDataString(v) : string.Empty));
+
         ValidateConverterEntities(e => e.StringCollection,
                                   (e, v) => e.StringCollection = v,
                                   firstStringList,
                                   secondStringList,
-                                  t => ((string)(object)t.StringCollection).Contains(secondStringList[1]));
+                                  t => (string)(object)t.StringCollection == serialisedSecondList);
     }
 
     [Theory]

--- a/tests/Data.EFCore.Tests/CollectionStringSplitConverterTests.cs
+++ b/tests/Data.EFCore.Tests/CollectionStringSplitConverterTests.cs
@@ -42,9 +42,9 @@ public class CollectionStringSplitConverterTests : DataIntegrationTest<Converter
     [AutoMockData]
     public void CollectionStringSplitConverter_should_handle_int_list(List<int> firstIntList, List<int> secondIntList)
     {
-        // Search for the complete serialised list rather than a single element: a short digit
-        // substring such as "4" can also match inside another entity's values (e.g. "147"),
-        // which made this test fail intermittently depending on the generated data.
+        // Match the complete serialised list exactly rather than searching for a single
+        // element: a short digit substring such as "4" can also match inside another
+        // entity's values (e.g. "147"), which made this test fail intermittently.
         // Mirror the converter's write format exactly (Uri.EscapeDataString per element,
         // string.Empty for default values) so the expected string cannot diverge from the
         // stored value regardless of the generated data.
@@ -54,7 +54,7 @@ public class CollectionStringSplitConverterTests : DataIntegrationTest<Converter
                                   (e, v) => e.IntCollection = v,
                                   firstIntList,
                                   secondIntList,
-                                  t => ((string)(object)t.IntCollection).Contains(serialisedSecondList));
+                                  t => (string)(object)t.IntCollection == serialisedSecondList);
     }
 
     [Theory]

--- a/tests/Data.EFCore.Tests/DbContextExtensionsTests.cs
+++ b/tests/Data.EFCore.Tests/DbContextExtensionsTests.cs
@@ -36,7 +36,7 @@ public class DbContextExtensionsTests : DataIntegrationTest<TestDbContext>
     [Fact]
     public void FindEntityType_should_find_requested_type_in_db_context()
     {
-        DbContext.FindEntityType(nameof(TestEntity)).Should().NotBeNull().And.Be(typeof(TestEntity));
+        DbContext.FindEntityType(nameof(TestEntity)).Should().NotBeNull().And.Be<TestEntity>();
     }
 
     [Fact]
@@ -57,8 +57,8 @@ public class DbContextExtensionsTests : DataIntegrationTest<TestDbContext>
         DbContext.ContainsEntityType(typeof(NonExistingEntity)).Should().BeFalse();
     }
 
-#pragma warning disable S2094 - we need to test the exception
-    private class NonExistingEntity
+#pragma warning disable S2094 // Classes should not be empty — a marker type absent from the model is needed for the negative tests
+    private sealed class NonExistingEntity
 #pragma warning restore S2094
     { }
 }

--- a/tests/Data.EFCore.Tests/GetStaticPropertyValueTests.cs
+++ b/tests/Data.EFCore.Tests/GetStaticPropertyValueTests.cs
@@ -1,3 +1,4 @@
+using System.Diagnostics.CodeAnalysis;
 using FluentAssertions;
 
 namespace Ploch.Data.EFCore.Tests;
@@ -44,13 +45,19 @@ public class GetStaticPropertyValueTests
         act.Should().Throw<InvalidOperationException>().WithMessage("*not of*type*");
     }
 
-    private class ClassWithStaticProperties
+    [SuppressMessage("Major Code Smell",
+                     "S1144:Unused private types or members should be removed",
+                     Justification = "All members are accessed via reflection through DbContextExtensions.GetStaticPropertyValue.")]
+    private static class ClassWithStaticProperties
     {
         public static string PublicValue { get; } = "public-value";
 
-        public static string? NullValue { get; } = null;
+        public static string? NullValue { get; }
 
         // ReSharper disable once UnusedMember.Local
+        [SuppressMessage("CodeQuality",
+                         "IDE0051:Remove unused private members",
+                         Justification = "Accessed via reflection by GetStaticPropertyValue_should_return_value_of_private_static_property.")]
         private static int PrivateValue { get; } = 42;
     }
 }

--- a/tests/Data.EFCore.Tests/GetStaticPropertyValueTests.cs
+++ b/tests/Data.EFCore.Tests/GetStaticPropertyValueTests.cs
@@ -45,6 +45,22 @@ public class GetStaticPropertyValueTests
         act.Should().Throw<InvalidOperationException>().WithMessage("*not of*type*");
     }
 
+    [Fact]
+    public void GetStaticPropertyValue_should_throw_ArgumentNullException_when_type_is_null()
+    {
+        var act = () => ((Type)null!).GetStaticPropertyValue<string>("PublicValue");
+
+        act.Should().Throw<ArgumentNullException>().WithParameterName("type");
+    }
+
+    [Fact]
+    public void GetStaticPropertyValue_should_throw_ArgumentNullException_when_property_name_is_null()
+    {
+        var act = () => typeof(ClassWithStaticProperties).GetStaticPropertyValue<string>(null!);
+
+        act.Should().Throw<ArgumentNullException>().WithParameterName("propertyName");
+    }
+
     [SuppressMessage("Major Code Smell",
                      "S1144:Unused private types or members should be removed",
                      Justification = "All members are accessed via reflection through DbContextExtensions.GetStaticPropertyValue.")]

--- a/tests/Data.StandardDataSets.Tests/CountriesTests.cs
+++ b/tests/Data.StandardDataSets.Tests/CountriesTests.cs
@@ -18,6 +18,6 @@ public class CountriesTests
     public void EnglishCountryNames_should_not_contain_duplicates()
     {
         var englishCountryNames = Regions.EnglishCountryNames();
-        englishCountryNames.Count().Should().Be(englishCountryNames.Select(name => name.ToLower()).Distinct().Count());
+        englishCountryNames.Count().Should().Be(englishCountryNames.Select(name => name.ToUpperInvariant()).Distinct().Count());
     }
 }

--- a/tests/Data.StandardDataSets.Tests/CountriesTests.cs
+++ b/tests/Data.StandardDataSets.Tests/CountriesTests.cs
@@ -18,6 +18,6 @@ public class CountriesTests
     public void EnglishCountryNames_should_not_contain_duplicates()
     {
         var englishCountryNames = Regions.EnglishCountryNames();
-        englishCountryNames.Count().Should().Be(englishCountryNames.Select(name => name.ToUpperInvariant()).Distinct().Count());
+        englishCountryNames.Count().Should().Be(englishCountryNames.Distinct(StringComparer.OrdinalIgnoreCase).Count());
     }
 }


### PR DESCRIPTION
## **User description**
# Pull Request Description

## Issue ticket number and link

Closes #90

## Pull Request Changes Summary

### :herb: Other

- Zero code-analysis warnings on `dotnet build Ploch.Data.slnx -c Release` — all 31 unique analyzer warnings (9 in shipping `src/`, 22 in tests) resolved. Remaining NU1603 lines are tracked by #68 (out of scope per the issue).

## Describe your changes

**Shipping `src/` (real fixes, no behaviour change):**

- `Data.EFCore/DbContextExtensions.cs` — `GetStaticPropertyValue` gained full XML docs (CS1591) and moved below the `Set` overloads so they are adjacent (S4136); reflection lookup uses `nameof(Set)` (CC0021); S3011 suppressed inline with justification — reading non-public static properties **is** the helper's documented purpose and is covered by `GetStaticPropertyValueTests`.
- `Data.GenericRepository.EFCore/ReadRepositoryAsync.cs` — new `protected AuditEntityHandler` property eliminates the CS9107 double capture (primary-ctor parameter was captured in the derived type *and* passed to base). Additive member; no API breakage.
- `Data.EFCore.SqLite/SqLiteDbContextConfigurator.cs` — primary constructor (IDE0290); `<param>` docs moved to class level.
- `Data.EFCore.SqLite/SqLiteDbContextFactory.cs` — CA1000 suppressed with justification: `CreationLifecycle` is intentionally accessed via concrete **non-generic** derived factories (e.g. `MyDbContextFactory.CreationLifecycle`), so callers never supply type arguments — the rule's rationale does not apply. Moving it off the generic type would be an unnecessary breaking change.
- `Data.EFCore.SqlServer/SqlServerDbContextFactory.cs` — SA1003 formatting.
- `Data.GenericRepository/RepositoriesConfiguration.cs` — CA1805 redundant `= false` removed.

**Tests:**

- Culture-explicit calls (CA1305/CA1304/CA1311). **Deliberate choice:** the converter tests use `CultureInfo.CurrentCulture` because `CollectionStringSplitConverter` currently *writes* with current culture — using invariant would break the tests on non-invariant machines. The converter's write/read culture asymmetry is a real latent bug, filed as **#97**; these call sites flip to invariant when it's fixed.
- Removed dead `Data` property (SA1137 — nothing references it via `[MemberData]`), commented-out code and the TODO comment (S125/SA1005/S1135 — the TODO's substance is preserved in follow-up issue **#98**), renamed `builder` → `modelBuilder` (CA1725/S927), sealed/static-ified test helper types (CA1852/RCS1102/S1118), fixed invalid pragma text (CS1696), generic FluentAssertions overload (CA2263), `ToUpperInvariant` for duplicate detection, `MyMethod` renamed per the test naming convention.
- Reflection-target members (`PrivateValue`, `NullValue`) carry `[SuppressMessage]` with justification — they are read via `GetStaticPropertyValue` reflection, which the analyzers cannot see.
- `tests/.editorconfig` — VSTHRD200 disabled for tests with the same rationale as the pre-existing `s4261` disable directly above it: the repository's test naming convention (`Method_should_do_X`) intentionally has no `Async` suffix, and xUnit test methods are never awaited by user code.

## Checklist before requesting a review

- [x] I have performed a self-review of my code
- [x] I have added thorough tests. *(No new behaviour — existing suite validates the refactors: 239 passed; the single failure is the pre-existing local-only assembly-skew issue #95, reproduced identically on `main`.)*
- [x] I have updated documentation. *(XML docs added where CS1591 flagged; no markdown docs describe the touched internals.)*
- [x] If applicable, I have updated the sample application *(not applicable — no API changes; SampleApp re-run end-to-end, exit 0)*

## :triangular_ruler: Design Decisions

- **Suppress CA1000 instead of moving `CreationLifecycle`** — moving it off the generic factory would break the public API for zero practical gain; access via non-generic derived factories already avoids the problem CA1000 exists to prevent.
- **`CurrentCulture` (not invariant) in converter tests** — matches the code under test's actual write behaviour; the underlying converter bug is tracked in #97 rather than silently changing shipping behaviour in a warnings-cleanup PR.
- **VSTHRD200 disabled at tests scope, not per-method renames** — renaming tests to `*_Async` would violate the repo's documented naming convention; the disable sits beside the identical, pre-existing `s4261` disable.
- **Second-opinion review note:** the usual pre-push Codex review could not run (the configured models are rejected for this account) and the local Gemini fallback has no API quota. Validation relied on a zero-warning build, the full test suite, and this PR's automated reviewers — all of whose findings will be addressed before merge.

## Testing

- `dotnet build Ploch.Data.slnx -c Release`: 0 errors, **0 code-analysis warnings** (down from 31 unique); only #68-tracked NU1603 remains.
- `dotnet test`: 239 passed / 1 failed — the failure is pre-existing #95 (Ploch.Common assembly-version skew from the sibling checkout), identical on `main`.
- SampleApp ConsoleApp ran end-to-end: `=== Sample Application Complete ===`, exit 0.

## Post-review updates (2026-07-24)

- **eeb1425** — int-list converter test now mirrors `CollectionStringSplitConverter`'s exact write format (`Uri.EscapeDataString` per element, `string.Empty` for default values) per Copilot review; the expected query string can no longer diverge from the stored value.
- **9e01c61** — docs typo fix ("baase" -> "base") in the converter's XML docs.
- **d32310b** — reflection lookup in `DbContextExtensions.GetEntitySet` now uses `nameof(DbContext.Set)` (was `nameof(Set)`, which bound to the local extension method by coincidence) per Copilot review; identical compiled string, no behaviour change.
- All review threads resolved; SonarCloud platform: 0 issues, 0 hotspots, quality gate OK (89.2% new-code coverage). Codacy's check suite has been stuck `queued` since eeb1425 (integration stalled on Codacy's side); completing without it was explicitly approved, its last verdict being a pass on 7757250.

## Related

- Closes #90
- Follow-ups filed: #97 (converter culture asymmetry), #98 (SQL Server container tests)
- Refs #68 (NU1603), #94 (v4.0.0 release umbrella)

<div id='description'>
<a href="https://bito.ai#summarystart"></a><h3>Summary by Bito</h3><ul><li>Refactored SqLiteDbContextConfigurator to use primary constructor and simplified options handling.</li>
<li>Moved GetStaticPropertyValue extension method to DbContextExtensions and added support for non-public properties.</li>
<li>Improved ReadRepositoryAsync to use a protected property for the audit handler and simplified RepositoriesConfiguration.</li>
<li>Updated various tests to improve code quality, including fixing test naming conventions and adding culture-aware string conversions.</li>
<li>Added threading analyzer suppression to .editorconfig for xUnit test methods.</li>
</ul></div>

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Improvements

* Streamlined SQLite setup and repository auditing behavior.
* Improved argument validation and reflection-based property access.
* Clarified audit-access defaults and connection-string configuration.

## Tests

* Expanded coverage for invalid arguments and serialized collection values.
* Updated test assertions, naming, formatting, and database setup.

## Documentation

* Corrected API documentation wording for collection conversion.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->


___

## **CodeAnt-AI Description**
Resolve analyzer issues while tightening validation and test reliability

### What Changed
- Static property lookup now rejects missing types or property names with clear argument errors.
- SQLite configuration keeps the default in-memory behavior and continues sharing one connection across contexts.
- Repository reads continue recording access audits through a validated audit handler.
- Collection conversion tests now match complete serialized values, avoiding incorrect matches when list elements overlap.
- Test coverage adds validation for invalid static-property lookup arguments and removes obsolete test code.

### Impact
`✅ Clearer invalid-argument errors`
`✅ Fewer false-positive collection conversion tests`
`✅ Reliable access auditing`
<details><summary><strong>💡 Usage Guide</strong></summary>

### Checking Your Pull Request
Every time you make a pull request, our system automatically looks through it. We check for security issues, mistakes in how you're setting up your infrastructure, and common code problems. We do this to make sure your changes are solid and won't cause any trouble later.

### Talking to CodeAnt AI
Got a question or need a hand with something in your pull request? You can easily get in touch with CodeAnt AI right here. Just type the following in a comment on your pull request, and replace "Your question here" with whatever you want to ask:
<pre>
<code>@codeant-ai ask: Your question here</code>
</pre>
This lets you have a chat with CodeAnt AI about your pull request, making it easier to understand and improve your code.

#### Example
<pre>
<code>@codeant-ai ask: Can you suggest a safer alternative to storing this secret?</code>
</pre>

### Preserve Org Learnings with CodeAnt
You can record team preferences so CodeAnt AI applies them in future reviews. Reply directly to the specific CodeAnt AI suggestion (in the same thread) and replace "Your feedback here" with your input:
<pre>
<code>@codeant-ai: Your feedback here</code>
</pre>
This helps CodeAnt AI learn and adapt to your team's coding style and standards.

#### Example
<pre>
<code>@codeant-ai: Do not flag unused imports.</code>
</pre>

### Retrigger review
Ask CodeAnt AI to review the PR again, by typing:
<pre>
<code>@codeant-ai: review</code>
</pre>

### Check Your Repository Health
To analyze the health of your code repository, visit our dashboard at [https://app.codeant.ai](https://app.codeant.ai). This tool helps you identify potential issues and areas for improvement in your codebase, ensuring your repository maintains high standards of code health.

</details>

