### PR TITLE
fix(generic-repository)!: Preserve creation-audit values on update

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -719,3 +719,11 @@ dotnet_diagnostic.CC0067.severity = none
 # for src/, SonarCloud then imported the diagnostics as external issues on PR #99, and discards
 # were added in response (commit 6f2d38f); those discards have been removed.
 dotnet_diagnostic.IDE0058.severity = none
+
+# CC0061 ("async method should end in Async") conflicts with the repository's test naming
+# convention (<Method>_should_<behaviour> — see .claude/rules/writing-dotnet-tests.md), which
+# deliberately omits the Async suffix from test method names. Disabled for test code only;
+# production code keeps the Async-suffix convention and the rule active. Refs: #88 (PR #100
+# SonarCloud findings; 56 pre-existing instances on main all stem from test methods).
+[tests/**.cs]
+dotnet_diagnostic.CC0061.severity = none

--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -2,6 +2,28 @@
 
 ## Unreleased
 
+### Fixed
+
+- **Repository updates no longer blank creation-audit properties on partial detached updates** —
+  `ReadWriteRepositoryAsync<TEntity, TId>.UpdateAsync` and `ReadWriteRepository<TEntity, TId>.Update`
+  used `CurrentValues.SetValues`, which copies every scalar from the supplied entity. Passing a
+  partial detached entity (e.g. `new Entity { Id = id, Name = "x" }`) silently overwrote the
+  persisted `CreatedTime` and `CreatedBy` values with defaults. The persisted values are now
+  restored after the copy, and the properties are excluded from the update.
+  See `change-log/issue-88-preserve-creation-audit-on-update.md`. (#88)
+
+  **Behavioural change:** when auditing is enabled (`RepositoriesConfiguration.EnableAuditing`,
+  the default), creation-audit properties (`IHasCreatedTime.CreatedTime`,
+  `IHasCreatedBy.CreatedBy`) are now write-once through the repository — values supplied to
+  `Update`/`UpdateAsync` are ignored and the persisted values are kept. To deliberately amend
+  creation-audit data (e.g. backfilling imported rows), use the `DbContext` directly or disable
+  auditing. With auditing disabled, updates keep plain full-entity semantics. All other properties
+  keep full-entity update semantics: any property left unset on the supplied entity is still
+  written to the store with its default value.
+
+  **Breaking change:** `IAuditEntityHandler` gained a new `IsAuditingEnabled` property. Custom
+  implementations of the interface must implement it.
+
 ### Security
 
 - **Fixed vulnerable transitive `SQLitePCLRaw.lib.e_sqlite3` (high severity,

--- a/change-log/issue-88-preserve-creation-audit-on-update.md
+++ b/change-log/issue-88-preserve-creation-audit-on-update.md
@@ -1,0 +1,61 @@
+# Context
+
+`ReadWriteRepositoryAsync<TEntity, TId>.UpdateAsync` and the synchronous
+`ReadWriteRepository<TEntity, TId>.Update` applied updates via
+`DbContext.Entry(exist).CurrentValues.SetValues(entity)`. `SetValues` copies **every** scalar
+property from the supplied entity onto the tracked one, so a *partial* detached entity
+(e.g. `new Blog { Id = id, Name = "x" }`) overwrote every unsupplied column with its CLR default —
+silently blanking the creation-audit fields `CreatedTime` and `CreatedBy`, which the library's
+`IAuditEntityHandler` sets once at insert and treats as write-once. ([#88](https://github.com/mrploch/ploch-data/issues/88))
+
+# Change
+
+- After `SetValues`, `Update`/`UpdateAsync` now restore the persisted values of
+  `IHasCreatedTime.CreatedTime` and `IHasCreatedBy.CreatedBy` from EF Core's `OriginalValue`
+  snapshot (the values loaded from the database) and mark the properties as not modified, so
+  they are excluded from the generated `UPDATE`. The shared logic lives in the internal
+  `CreationAuditPropertyProtector` used by both repositories.
+- The protection is gated on `RepositoriesConfiguration.EnableAuditing` — the same flag that
+  gates all other audit behaviour in `AuditEntityHandler`. With auditing disabled, updates keep
+  plain full-entity semantics and the library stays neutral about creation-audit properties.
+- Properties are only touched when the entity implements the corresponding interface **and** the
+  property is mapped in the EF model (`entry.Metadata.FindProperty` guard).
+- `IAuditEntityHandler` gained an `IsAuditingEnabled` property (**breaking** for custom
+  implementations) so repositories can honour the auditing flag without depending on
+  `IOptions<RepositoriesConfiguration>` directly.
+- XML documentation on `IWriteRepositoryAsync.UpdateAsync` and `IWriteRepository.Update` now
+  spells out the full-entity update semantics and the creation-audit immutability.
+
+# Impact
+
+- **Behavioural change (v4.0):** with auditing enabled (the default), creation-audit properties
+  are now immutable through `Update`/`UpdateAsync`. Values supplied by the caller — deliberately
+  or via a partial detached entity — are ignored and the persisted values are kept. Use the
+  `DbContext` directly (or disable auditing) for deliberate creation-audit maintenance
+  (e.g. backfilling imported rows).
+- All other properties keep the existing full-entity update semantics: unsupplied properties on a
+  detached entity are still written with their defaults. Partial updates remain unsupported and
+  are now documented as such.
+- The fetch-modify-update pattern is unaffected, except that direct mutation of `CreatedTime`/
+  `CreatedBy` on a tracked entity is also reverted by `UpdateAsync` when auditing is enabled.
+
+# Design notes
+
+- Protection is keyed on the `IHasCreatedTime`/`IHasCreatedBy` **interfaces**, matching how
+  `AuditEntityHandler` itself decides which properties to audit. Entities with a column merely
+  named `CreatedTime` that never opted into the audit contract are not affected.
+- Shadow properties need no protection: `PropertyValues.SetValues(object)` only copies values from
+  matching readable CLR properties, so shadow columns are never touched by the copy.
+
+# Tests
+
+Six integration tests added:
+
+- `ReadWriteRepositoryAsyncAuditTests` — partial detached update preserves persisted
+  `CreatedTime`/`CreatedBy` and still sets `ModifiedTime`; a fully-formed entity supplying
+  different creation-audit values has them ignored; null creation-audit values in the store stay
+  null when the caller attempts to backfill them; direct mutation on a tracked entity is ignored.
+- `ReadWriteRepositoryAuditTests` — the synchronous `Update` preserves creation audit on a partial
+  detached update.
+- `ReadWriteRepositoryAsyncAuditingDisabledTests` — with `EnableAuditing = false`, supplied
+  creation-audit values are applied verbatim and `ModifiedTime` is not set.

--- a/docs/extending.md
+++ b/docs/extending.md
@@ -298,6 +298,10 @@ public class CustomAuditHandler : IAuditEntityHandler
         _userService = userService;
     }
 
+    // Gates audit behaviour, including the creation-audit protection applied
+    // by Update/UpdateAsync. Return false to disable auditing entirely.
+    public bool IsAuditingEnabled => true;
+
     public void HandleCreation(object entity)
     {
         if (entity is IHasCreatedTime created)

--- a/docs/generic-repository.md
+++ b/docs/generic-repository.md
@@ -151,6 +151,18 @@ await repository.UpdateAsync(existing);
 
 **Note:** `UpdateAsync` throws `EntityNotFoundException` if the entity does not exist.
 
+**Update semantics:** `UpdateAsync` (and the synchronous `Update`) applies **every** scalar
+property of the supplied entity to the stored entity. Partial updates are not supported — any
+property left unset on a detached entity is written to the store with its default value, so prefer
+the fetch-modify-update pattern shown above.
+
+The exception is creation audit: when auditing is enabled (`RepositoriesConfiguration.EnableAuditing`,
+the default), for entities implementing `IHasCreatedTime` or `IHasCreatedBy` the persisted
+`CreatedTime` and `CreatedBy` values are preserved and cannot be changed through
+`Update`/`UpdateAsync` — creation audit is write-once, set when the entity is added. To
+deliberately amend creation-audit data (e.g. backfilling imported rows), use the `DbContext`
+directly or disable auditing.
+
 ### DeleteAsync
 
 By entity reference or by ID:

--- a/src/Data.GenericRepository/Data.GenericRepository.EFCore/CreationAuditPropertyProtector.cs
+++ b/src/Data.GenericRepository/Data.GenericRepository.EFCore/CreationAuditPropertyProtector.cs
@@ -1,0 +1,46 @@
+using Microsoft.EntityFrameworkCore.ChangeTracking;
+using Ploch.Data.Model;
+
+namespace Ploch.Data.GenericRepository.EFCore;
+
+/// <summary>
+///     Protects creation-audit properties from being overwritten when an update is applied via
+///     <see cref="PropertyValues.SetValues(object)" />.
+/// </summary>
+internal static class CreationAuditPropertyProtector
+{
+    /// <summary>
+    ///     Restores the persisted values of the creation-audit properties on the supplied entry.
+    /// </summary>
+    /// <param name="entry">The tracked entry the update was applied to.</param>
+    /// <remarks>
+    ///     SetValues copies every scalar from the supplied entity, so a partial detached entity
+    ///     would overwrite the persisted creation-audit values with defaults. Creation audit is
+    ///     write-once (set by <see cref="IAuditEntityHandler" /> on add), so the values loaded from
+    ///     the database are restored and the properties are excluded from the update.
+    /// </remarks>
+    public static void RestoreCreationAuditValues(EntityEntry entry)
+    {
+        if (entry.Entity is IHasCreatedTime)
+        {
+            RestoreOriginalValue(entry, nameof(IHasCreatedTime.CreatedTime));
+        }
+
+        if (entry.Entity is IHasCreatedBy)
+        {
+            RestoreOriginalValue(entry, nameof(IHasCreatedBy.CreatedBy));
+        }
+    }
+
+    private static void RestoreOriginalValue(EntityEntry entry, string propertyName)
+    {
+        if (entry.Metadata.FindProperty(propertyName) == null)
+        {
+            return;
+        }
+
+        var property = entry.Property(propertyName);
+        property.CurrentValue = property.OriginalValue;
+        property.IsModified = false;
+    }
+}

--- a/src/Data.GenericRepository/Data.GenericRepository.EFCore/ReadWriteRepository.cs
+++ b/src/Data.GenericRepository/Data.GenericRepository.EFCore/ReadWriteRepository.cs
@@ -81,6 +81,12 @@ public class ReadWriteRepository<TEntity, TId>(DbContext dbContext, IAuditEntity
 
         auditEntityHandler.HandleModification(entity);
 
-        DbContext.Entry(exist).CurrentValues.SetValues(entity);
+        var entry = DbContext.Entry(exist);
+        entry.CurrentValues.SetValues(entity);
+
+        if (auditEntityHandler.IsAuditingEnabled)
+        {
+            CreationAuditPropertyProtector.RestoreCreationAuditValues(entry);
+        }
     }
 }

--- a/src/Data.GenericRepository/Data.GenericRepository.EFCore/ReadWriteRepositoryAsync.cs
+++ b/src/Data.GenericRepository/Data.GenericRepository.EFCore/ReadWriteRepositoryAsync.cs
@@ -72,6 +72,7 @@ public class ReadWriteRepositoryAsync<TEntity, TId>(DbContext dbContext, IAuditE
         await DeleteAsync(entity, cancellationToken);
     }
 
+    /// <inheritdoc />
     public virtual async Task UpdateAsync(TEntity entity, CancellationToken cancellationToken = default)
     {
         entity.NotNull();
@@ -83,6 +84,13 @@ public class ReadWriteRepositoryAsync<TEntity, TId>(DbContext dbContext, IAuditE
         }
 
         _auditEntityHandler.HandleModification(entity);
-        DbContext.Entry(exist).CurrentValues.SetValues(entity);
+
+        var entry = DbContext.Entry(exist);
+        entry.CurrentValues.SetValues(entity);
+
+        if (_auditEntityHandler.IsAuditingEnabled)
+        {
+            CreationAuditPropertyProtector.RestoreCreationAuditValues(entry);
+        }
     }
 }

--- a/src/Data.GenericRepository/Data.GenericRepository/AuditEntityHandler.cs
+++ b/src/Data.GenericRepository/Data.GenericRepository/AuditEntityHandler.cs
@@ -14,13 +14,16 @@ namespace Ploch.Data.GenericRepository;
 /// <param name="configuration">Configuration options for repositories, including auditing settings.</param>
 public class AuditEntityHandler(IUserInfoProvider userInfoProvider, TimeProvider timeProvider, IOptions<RepositoriesConfiguration> configuration) : IAuditEntityHandler
 {
+    /// <inheritdoc />
+    public bool IsAuditingEnabled => configuration.Value.EnableAuditing;
+
     /// <summary>
     ///     Handles the creation auditing for an entity by setting creation time and creator information.
     /// </summary>
     /// <param name="entity">The entity being created that may implement auditing interfaces.</param>
     public void HandleCreation(object entity)
     {
-        if (configuration.Value.EnableAuditing)
+        if (IsAuditingEnabled)
         {
             if (entity is IHasCreatedTime createdTimeEntity)
             {
@@ -40,7 +43,7 @@ public class AuditEntityHandler(IUserInfoProvider userInfoProvider, TimeProvider
     /// <param name="entity">The entity being modified that may implement auditing interfaces.</param>
     public void HandleModification(object entity)
     {
-        if (configuration.Value.EnableAuditing)
+        if (IsAuditingEnabled)
         {
             if (entity is IHasModifiedTime modifiedTimeEntity)
             {

--- a/src/Data.GenericRepository/Data.GenericRepository/IAuditEntityHandler.cs
+++ b/src/Data.GenericRepository/Data.GenericRepository/IAuditEntityHandler.cs
@@ -6,6 +6,15 @@ namespace Ploch.Data.GenericRepository;
 public interface IAuditEntityHandler
 {
     /// <summary>
+    ///     Gets a value indicating whether entity auditing is enabled.
+    /// </summary>
+    /// <value>
+    ///     <see langword="true" /> if auditing operations (setting audit properties and protecting
+    ///     creation-audit properties during updates) should be performed; otherwise, <see langword="false" />.
+    /// </value>
+    bool IsAuditingEnabled { get; }
+
+    /// <summary>
     ///     Handles the creation of an entity by performing audit-related operations.
     /// </summary>
     /// <param name="entity">

--- a/src/Data.GenericRepository/Data.GenericRepository/IWriteRepository.cs
+++ b/src/Data.GenericRepository/Data.GenericRepository/IWriteRepository.cs
@@ -29,6 +29,20 @@ public interface IWriteRepository<TEntity, in TId>
     /// <summary>
     ///     Updates the specified entity in the repository.
     /// </summary>
+    /// <remarks>
+    ///     <para>
+    ///         The update applies every scalar property of <paramref name="entity" /> to the stored entity.
+    ///         Partial updates are not supported: any property the caller leaves unset is written to the
+    ///         store with its default value. Use the fetch-modify-update pattern to change a subset of
+    ///         properties safely.
+    ///     </para>
+    ///     <para>
+    ///         Creation-audit properties are the exception. When auditing is enabled, for entities
+    ///         implementing <see cref="IHasCreatedTime" /> or <see cref="IHasCreatedBy" />, the persisted
+    ///         <c>CreatedTime</c> and <c>CreatedBy</c> values are preserved and cannot be changed
+    ///         through this method — creation audit is write-once, set when the entity is added.
+    ///     </para>
+    /// </remarks>
     /// <param name="entity">The entity to update.</param>
     void Update(TEntity entity);
 

--- a/src/Data.GenericRepository/Data.GenericRepository/IWriteRepositoryAsync.cs
+++ b/src/Data.GenericRepository/Data.GenericRepository/IWriteRepositoryAsync.cs
@@ -34,6 +34,20 @@ public interface IWriteRepositoryAsync<TEntity, in TId>
     /// <summary>
     ///     Asynchronously updates the specified entity in the repository.
     /// </summary>
+    /// <remarks>
+    ///     <para>
+    ///         The update applies every scalar property of <paramref name="entity" /> to the stored entity.
+    ///         Partial updates are not supported: any property the caller leaves unset is written to the
+    ///         store with its default value. Use the fetch-modify-update pattern to change a subset of
+    ///         properties safely.
+    ///     </para>
+    ///     <para>
+    ///         Creation-audit properties are the exception. When auditing is enabled, for entities
+    ///         implementing <see cref="IHasCreatedTime" /> or <see cref="IHasCreatedBy" />, the persisted
+    ///         <c>CreatedTime</c> and <c>CreatedBy</c> values are preserved and cannot be changed
+    ///         through this method — creation audit is write-once, set when the entity is added.
+    ///     </para>
+    /// </remarks>
     /// <param name="entity">The entity to update.</param>
     /// <param name="cancellationToken">A <see cref="CancellationToken" /> to observe while waiting for the task to complete.</param>
     /// <returns>A task that represents the asynchronous operation.</returns>

--- a/tests/Data.GenericRepository/Data.GenericRepository.EFCore.IntegrationTests/ReadWriteRepositoryAsyncAuditTests.cs
+++ b/tests/Data.GenericRepository/Data.GenericRepository.EFCore.IntegrationTests/ReadWriteRepositoryAsyncAuditTests.cs
@@ -29,6 +29,126 @@ public class ReadWriteRepositoryAsyncAuditTests : GenericRepositoryDataIntegrati
     }
 
     [Fact]
+    public async Task UpdateAsync_should_preserve_creation_audit_properties_on_partial_detached_update()
+    {
+        // Arrange — seed via the plain DbContext with known creation-audit values; the repository
+        // write path is the code under test, so it must not be used for seeding.
+        var createdTime = DateTimeOffset.UtcNow.AddDays(-1);
+        var blog = new Blog { Name = "Original Name", CreatedTime = createdTime, CreatedBy = "original-creator" };
+        DbContext.Blogs.Add(blog);
+        await DbContext.SaveChangesAsync();
+        DbContext.ChangeTracker.Clear();
+
+        // Act — a partial detached entity supplies only Id and Name; every other property is at its default.
+        var unitOfWork = CreateUnitOfWork();
+        await unitOfWork.Repository<Blog, int>().UpdateAsync(new Blog { Id = blog.Id, Name = "Updated Name" });
+        await unitOfWork.CommitAsync();
+
+        // Assert — verify via a fresh DbContext so values are re-hydrated from the database.
+        var rootDbContext = CreateRootDbContext();
+        var updatedBlog = await rootDbContext.Set<Blog>().FindAsync(blog.Id);
+        updatedBlog.Should().NotBeNull();
+        updatedBlog!.Name.Should().Be("Updated Name");
+        updatedBlog.CreatedTime.Should().NotBeNull("a partial detached update must not blank the creation timestamp");
+        updatedBlog.CreatedTime!.Value.Should().BeCloseTo(createdTime, TimeSpan.FromMilliseconds(1));
+        updatedBlog.CreatedBy.Should().Be("original-creator", "a partial detached update must not blank the creator");
+        updatedBlog.ModifiedTime.Should().NotBeNull();
+    }
+
+    [Fact]
+    public async Task UpdateAsync_should_ignore_caller_supplied_creation_audit_values()
+    {
+        // Arrange
+        var createdTime = DateTimeOffset.UtcNow.AddDays(-2);
+        var blog = new Blog { Name = "Original Name", CreatedTime = createdTime, CreatedBy = "original-creator" };
+        DbContext.Blogs.Add(blog);
+        await DbContext.SaveChangesAsync();
+        DbContext.ChangeTracker.Clear();
+
+        // Act — a fully-formed detached entity deliberately supplies different creation-audit values.
+        var tamperedBlog = new Blog
+        {
+            Id = blog.Id,
+            Name = "Updated Name",
+            CreatedTime = DateTimeOffset.UtcNow,
+            CreatedBy = "someone-else"
+        };
+        var unitOfWork = CreateUnitOfWork();
+        await unitOfWork.Repository<Blog, int>().UpdateAsync(tamperedBlog);
+        await unitOfWork.CommitAsync();
+
+        // Assert — creation audit is immutable through the repository; the supplied values are ignored.
+        var rootDbContext = CreateRootDbContext();
+        var updatedBlog = await rootDbContext.Set<Blog>().FindAsync(blog.Id);
+        updatedBlog.Should().NotBeNull();
+        updatedBlog!.Name.Should().Be("Updated Name");
+        updatedBlog.CreatedTime.Should().NotBeNull();
+        updatedBlog.CreatedTime!.Value.Should().BeCloseTo(createdTime, TimeSpan.FromMilliseconds(1));
+        updatedBlog.CreatedBy.Should().Be("original-creator");
+    }
+
+    [Fact]
+    public async Task UpdateAsync_should_keep_null_creation_audit_values_when_caller_supplies_them()
+    {
+        // Arrange — an entity persisted without creation-audit values (e.g. imported data).
+        var blog = new Blog { Name = "Original Name" };
+        DbContext.Blogs.Add(blog);
+        await DbContext.SaveChangesAsync();
+        DbContext.ChangeTracker.Clear();
+
+        // Act — the caller attempts to backfill creation-audit values through UpdateAsync.
+        var updateBlog = new Blog
+        {
+            Id = blog.Id,
+            Name = "Updated Name",
+            CreatedTime = DateTimeOffset.UtcNow,
+            CreatedBy = "backfiller"
+        };
+        var unitOfWork = CreateUnitOfWork();
+        await unitOfWork.Repository<Blog, int>().UpdateAsync(updateBlog);
+        await unitOfWork.CommitAsync();
+
+        // Assert — creation audit stays exactly as persisted, including null.
+        var rootDbContext = CreateRootDbContext();
+        var updatedBlog = await rootDbContext.Set<Blog>().FindAsync(blog.Id);
+        updatedBlog.Should().NotBeNull();
+        updatedBlog!.Name.Should().Be("Updated Name");
+        updatedBlog.CreatedTime.Should().BeNull();
+        updatedBlog.CreatedBy.Should().BeNull();
+    }
+
+    [Fact]
+    public async Task UpdateAsync_should_ignore_creation_audit_changes_on_tracked_entity()
+    {
+        // Arrange
+        var createdTime = DateTimeOffset.UtcNow.AddDays(-3);
+        var blog = new Blog { Name = "Original Name", CreatedTime = createdTime, CreatedBy = "original-creator" };
+        DbContext.Blogs.Add(blog);
+        await DbContext.SaveChangesAsync();
+        DbContext.ChangeTracker.Clear();
+
+        // Act — fetch-modify-update on the same tracked instance, mutating creation audit directly.
+        var unitOfWork = CreateUnitOfWork();
+        var repository = unitOfWork.Repository<Blog, int>();
+        var trackedBlog = await repository.GetByIdAsync(blog.Id);
+        trackedBlog.Should().NotBeNull();
+        trackedBlog!.Name = "Updated Name";
+        trackedBlog.CreatedTime = DateTimeOffset.UtcNow;
+        trackedBlog.CreatedBy = "someone-else";
+        await repository.UpdateAsync(trackedBlog);
+        await unitOfWork.CommitAsync();
+
+        // Assert — the direct mutation of creation audit is ignored; the persisted values are kept.
+        var rootDbContext = CreateRootDbContext();
+        var updatedBlog = await rootDbContext.Set<Blog>().FindAsync(blog.Id);
+        updatedBlog.Should().NotBeNull();
+        updatedBlog!.Name.Should().Be("Updated Name");
+        updatedBlog.CreatedTime.Should().NotBeNull();
+        updatedBlog.CreatedTime!.Value.Should().BeCloseTo(createdTime, TimeSpan.FromMilliseconds(1));
+        updatedBlog.CreatedBy.Should().Be("original-creator");
+    }
+
+    [Fact]
     public async Task Add_and_CommitAsync_should_update_created_time_audit_property()
     {
         var unitOfWork = CreateUnitOfWork();

--- a/tests/Data.GenericRepository/Data.GenericRepository.EFCore.IntegrationTests/ReadWriteRepositoryAsyncAuditingDisabledTests.cs
+++ b/tests/Data.GenericRepository/Data.GenericRepository.EFCore.IntegrationTests/ReadWriteRepositoryAsyncAuditingDisabledTests.cs
@@ -1,0 +1,49 @@
+using Microsoft.Extensions.DependencyInjection;
+using Ploch.Data.GenericRepository.EFCore.IntegrationTesting;
+using Ploch.Data.GenericRepository.EFCore.IntegrationTests.Model;
+
+namespace Ploch.Data.GenericRepository.EFCore.IntegrationTests;
+
+public class ReadWriteRepositoryAsyncAuditingDisabledTests : GenericRepositoryDataIntegrationTest<TestDbContext>
+{
+    protected override void ConfigureServices(IServiceCollection services)
+    {
+        base.ConfigureServices(services);
+        services.Configure<RepositoriesConfiguration>(static configuration => configuration.EnableAuditing = false);
+    }
+
+    [Fact]
+    public async Task UpdateAsync_should_apply_supplied_creation_audit_values_when_auditing_is_disabled()
+    {
+        // Arrange
+        var originalCreatedTime = DateTimeOffset.UtcNow.AddDays(-1);
+        var blog = new Blog { Name = "Original Name", CreatedTime = originalCreatedTime, CreatedBy = "original-creator" };
+        DbContext.Blogs.Add(blog);
+        await DbContext.SaveChangesAsync();
+        DbContext.ChangeTracker.Clear();
+
+        // Act — with auditing disabled, the library must stay neutral: a plain full-entity update
+        // with no creation-audit protection, matching AuditEntityHandler's own EnableAuditing gate.
+        var newCreatedTime = DateTimeOffset.UtcNow;
+        var updateBlog = new Blog
+        {
+            Id = blog.Id,
+            Name = "Updated Name",
+            CreatedTime = newCreatedTime,
+            CreatedBy = "new-creator"
+        };
+        var unitOfWork = CreateUnitOfWork();
+        await unitOfWork.Repository<Blog, int>().UpdateAsync(updateBlog);
+        await unitOfWork.CommitAsync();
+
+        // Assert — supplied values are applied verbatim and ModifiedTime is not set.
+        var rootDbContext = CreateRootDbContext();
+        var updatedBlog = await rootDbContext.Set<Blog>().FindAsync(blog.Id);
+        updatedBlog.Should().NotBeNull();
+        updatedBlog!.Name.Should().Be("Updated Name");
+        updatedBlog.CreatedTime.Should().NotBeNull();
+        updatedBlog.CreatedTime!.Value.Should().BeCloseTo(newCreatedTime, TimeSpan.FromMilliseconds(1));
+        updatedBlog.CreatedBy.Should().Be("new-creator");
+        updatedBlog.ModifiedTime.Should().BeNull("auditing is disabled, so the modification timestamp is not set");
+    }
+}

--- a/tests/Data.GenericRepository/Data.GenericRepository.EFCore.IntegrationTests/ReadWriteRepositoryAsyncAuditingDisabledTests.cs
+++ b/tests/Data.GenericRepository/Data.GenericRepository.EFCore.IntegrationTests/ReadWriteRepositoryAsyncAuditingDisabledTests.cs
@@ -6,12 +6,6 @@ namespace Ploch.Data.GenericRepository.EFCore.IntegrationTests;
 
 public class ReadWriteRepositoryAsyncAuditingDisabledTests : GenericRepositoryDataIntegrationTest<TestDbContext>
 {
-    protected override void ConfigureServices(IServiceCollection services)
-    {
-        base.ConfigureServices(services);
-        services.Configure<RepositoriesConfiguration>(static configuration => configuration.EnableAuditing = false);
-    }
-
     [Fact]
     public async Task UpdateAsync_should_apply_supplied_creation_audit_values_when_auditing_is_disabled()
     {
@@ -45,5 +39,11 @@ public class ReadWriteRepositoryAsyncAuditingDisabledTests : GenericRepositoryDa
         updatedBlog.CreatedTime!.Value.Should().BeCloseTo(newCreatedTime, TimeSpan.FromMilliseconds(1));
         updatedBlog.CreatedBy.Should().Be("new-creator");
         updatedBlog.ModifiedTime.Should().BeNull("auditing is disabled, so the modification timestamp is not set");
+    }
+
+    protected override void ConfigureServices(IServiceCollection services)
+    {
+        base.ConfigureServices(services);
+        services.Configure<RepositoriesConfiguration>(static configuration => configuration.EnableAuditing = false);
     }
 }

--- a/tests/Data.GenericRepository/Data.GenericRepository.EFCore.IntegrationTests/ReadWriteRepositoryAuditTests.cs
+++ b/tests/Data.GenericRepository/Data.GenericRepository.EFCore.IntegrationTests/ReadWriteRepositoryAuditTests.cs
@@ -1,0 +1,33 @@
+using Ploch.Data.GenericRepository.EFCore.IntegrationTesting;
+using Ploch.Data.GenericRepository.EFCore.IntegrationTests.Model;
+
+namespace Ploch.Data.GenericRepository.EFCore.IntegrationTests;
+
+public class ReadWriteRepositoryAuditTests : GenericRepositoryDataIntegrationTest<TestDbContext>
+{
+    [Fact]
+    public void Update_should_preserve_creation_audit_properties_on_partial_detached_update()
+    {
+        // Arrange — seed via the plain DbContext with known creation-audit values; the repository
+        // write path is the code under test, so it must not be used for seeding.
+        var createdTime = DateTimeOffset.UtcNow.AddDays(-1);
+        var blog = new Blog { Name = "Original Name", CreatedTime = createdTime, CreatedBy = "original-creator" };
+        DbContext.Blogs.Add(blog);
+        DbContext.SaveChanges();
+        DbContext.ChangeTracker.Clear();
+
+        // Act — a partial detached entity supplies only Id and Name; every other property is at its default.
+        var repository = CreateReadWriteRepository<Blog, int>();
+        repository.Update(new Blog { Id = blog.Id, Name = "Updated Name" });
+        DbContext.SaveChanges();
+
+        // Assert — verify via a fresh DbContext so values are re-hydrated from the database.
+        var rootDbContext = CreateRootDbContext();
+        var updatedBlog = rootDbContext.Set<Blog>().Find(blog.Id);
+        updatedBlog.Should().NotBeNull();
+        updatedBlog!.Name.Should().Be("Updated Name");
+        updatedBlog.CreatedTime.Should().NotBeNull("a partial detached update must not blank the creation timestamp");
+        updatedBlog.CreatedTime!.Value.Should().BeCloseTo(createdTime, TimeSpan.FromMilliseconds(1));
+        updatedBlog.CreatedBy.Should().Be("original-creator", "a partial detached update must not blank the creator");
+    }
+}


### PR DESCRIPTION
## **User description**
## Issue ticket number and link

Closes #88 — [ReadWriteRepositoryAsync.UpdateAsync blanks unsupplied columns (incl. CreatedTime) on partial detached update](https://github.com/mrploch/ploch-data/issues/88)

## Pull Request Changes Summary

### :boom: Breaking Changes

- `IAuditEntityHandler` gained a new `bool IsAuditingEnabled { get; }` property — custom implementations must implement it (see `docs/extending.md` for the updated sample).
- Creation-audit properties (`IHasCreatedTime.CreatedTime`, `IHasCreatedBy.CreatedBy`) are now **write-once through the repository** while auditing is enabled: values supplied to `Update`/`UpdateAsync` are ignored and the persisted values are kept.

### :beetle: Fixes

- `ReadWriteRepositoryAsync.UpdateAsync` **and** the synchronous `ReadWriteRepository.Update` no longer blank persisted `CreatedTime`/`CreatedBy` when a partial detached entity is supplied. Both paths restore the persisted values from EF Core's `OriginalValue` snapshot after `CurrentValues.SetValues` and exclude the properties from the generated `UPDATE`.

### :book: Docs

- XML docs on `IWriteRepositoryAsync.UpdateAsync` and `IWriteRepository.Update` now document the full-entity update semantics (partial updates unsupported) and creation-audit immutability.
- `RELEASE_NOTES.md`, `docs/generic-repository.md`, `docs/extending.md` (custom handler sample now implements `IsAuditingEnabled`), and `change-log/issue-88-preserve-creation-audit-on-update.md` updated.

## Describe your changes

`CurrentValues.SetValues(entity)` copies **every** scalar from the supplied entity, so `repository.UpdateAsync(new Entity { Id = id, Name = "x" })` silently overwrote every unsupplied column — including the creation-audit fields the library itself sets once at insert — with CLR defaults. This was the known data-corruption path gating the v4.0 release (#94).

The fix introduces an internal `CreationAuditPropertyProtector` shared by both the async and sync repositories. After `SetValues`, it restores `CreatedTime`/`CreatedBy` from the `OriginalValue` snapshot (the values loaded from the database) and marks them `IsModified = false`. Protection only applies when the entity implements the corresponding `Ploch.Data.Model` interface **and** the property is mapped in the EF model, and only when auditing is enabled.

## Checklist before requesting a review

- [x] I have performed a self-review of my code
- [x] I have added thorough tests.
- [x] I have updated documentation.
- [x] If applicable, I have updated the sample application — N/A: the SampleApp consumes published 3.x packages and cannot demonstrate the 4.0 behaviour until the packages ship; no API surface it uses changed.

## :triangular_ruler: Design Decisions

- **Protect rather than only document** — #88 offered both options. EF Core cannot distinguish "not supplied" from "deliberately defaulted" for arbitrary properties, so general partial updates stay unsupported (now documented); but creation audit is an invariant the library itself establishes at insert, so the library enforces its immutability. This ships in v4.0 where the behavioural change is allowed (#94 explicitly requires this bug not to ship).
- **Gate on `EnableAuditing`** — the protection follows the same `RepositoriesConfiguration.EnableAuditing` flag as every other audit path (`AuditEntityHandler`). With auditing disabled the library stays neutral and updates keep plain full-entity semantics. Exposed via `IAuditEntityHandler.IsAuditingEnabled` so repositories do not need `IOptions<RepositoriesConfiguration>`.
- **Key protection on the audit interfaces, not property names** — matches how `AuditEntityHandler` decides what to audit. Entities with a column merely named `CreatedTime` that never opted into the audit contract are unaffected. Shadow properties need no protection: `PropertyValues.SetValues(object)` only copies from matching readable CLR properties, so shadow columns are never touched by the copy (evaluated and declined a reviewer suggestion to key on model property names for this reason).
- **Review process note** — the Codex MCP models are unavailable on this account (400 for `gpt-5.3-codex` and `gpt-5.1-codex-max`); per the implement-issue skill fallback, the plan was reviewed by Gemini (APPROVED_WITH_NOTES) and the diff by an independent local review agent (two passes: CHANGES_REQUESTED → both findings fixed → APPROVED_WITH_NOTES).

## Testing

- **Bug-fix protocol:** three regression tests were written first and confirmed failing on `main` for exactly the reported corruption, then the fix made them pass.
- **6 new integration tests** (SQLite in-memory, assertions via a fresh root `DbContext` per the repo's integration-testing rules):
  - partial detached `UpdateAsync` preserves `CreatedTime`/`CreatedBy`, still sets `ModifiedTime`;
  - fully-formed entity supplying different creation-audit values → ignored;
  - null creation-audit values in the store stay null when the caller attempts a backfill;
  - fetch-modify-update on the tracked instance with directly mutated creation audit → ignored;
  - synchronous `Update` partial detached update preserves creation audit;
  - `EnableAuditing = false` → supplied values applied verbatim, `ModifiedTime` not set.
- **Full suite:** 248 passed, 0 failed, 1 pre-existing skip (SQL Server container, #98). Zero new build warnings (remaining NU1603/MSB3277 are pre-existing environment warnings tracked by #67/#68/#95).
- Coverage on new code: all new branches exercised by the tests above.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

## Summary by Sourcery

Ensure repository updates preserve creation-audit fields while documenting full-entity update semantics and gating behaviour on auditing configuration.

Bug Fixes:
- Prevent ReadWriteRepository and ReadWriteRepositoryAsync from blanking persisted CreatedTime/CreatedBy during partial detached updates by restoring original creation-audit values.

Enhancements:
- Make creation-audit properties effectively write-once through repository Update/UpdateAsync when auditing is enabled, keyed off audit interfaces and configuration.
- Expose an IsAuditingEnabled flag on IAuditEntityHandler so repositories can respect auditing configuration without direct options dependencies.
- Introduce a shared CreationAuditPropertyProtector to centralise creation-audit protection logic for sync and async repositories.

Documentation:
- Document full-entity update semantics, the lack of partial update support, and creation-audit immutability in XML docs and generic-repository documentation.
- Add a change-log entry and release notes describing the creation-audit protection behaviour and the associated breaking change for custom audit handlers.

Tests:
- Add integration tests covering async and sync update behaviour for creation-audit preservation, tracked-entity mutations, and auditing-disabled scenarios.

<div id='description'>
<a href="https://bito.ai#summarystart"></a><h3>Summary by Bito</h3><ul><li>Fixed an issue where partial detached entity updates would overwrite creation-audit properties (CreatedTime, CreatedBy) with default values.</li>
<li>Implemented creation-audit property protection in ReadWriteRepository and ReadWriteRepositoryAsync, ensuring these fields remain immutable when auditing is enabled.</li>
<li>Added an IsAuditingEnabled property to IAuditEntityHandler, which is a breaking change for custom implementations.</li>
<li>Updated documentation to clarify full-entity update semantics and creation-audit immutability.</li>
<li>Added six integration tests to verify audit preservation and behavior when auditing is disabled.</li>
</ul></div>


___

## **CodeAnt-AI Description**
Preserve creation audit data during repository updates

### What Changed
- Synchronous and asynchronous updates now keep the stored creation time and creator when auditing is enabled, including for partial detached entities.
- Caller-supplied changes to creation-audit fields are ignored through repository updates, while modification auditing continues to work.
- When auditing is disabled, updates retain their existing behavior and apply supplied creation-audit values.
- Update documentation now explains full-entity semantics, creation-audit immutability, and the required interface change for custom audit handlers.

### Impact
`✅ Fewer records with blank creation timestamps`
`✅ Protected creation history during updates`
`✅ Controlled creation-audit maintenance when auditing is disabled`
<details><summary><strong>💡 Usage Guide</strong></summary>

### Checking Your Pull Request
Every time you make a pull request, our system automatically looks through it. We check for security issues, mistakes in how you're setting up your infrastructure, and common code problems. We do this to make sure your changes are solid and won't cause any trouble later.

### Talking to CodeAnt AI
Got a question or need a hand with something in your pull request? You can easily get in touch with CodeAnt AI right here. Just type the following in a comment on your pull request, and replace "Your question here" with whatever you want to ask:
<pre>
<code>@codeant-ai ask: Your question here</code>
</pre>
This lets you have a chat with CodeAnt AI about your pull request, making it easier to understand and improve your code.

#### Example
<pre>
<code>@codeant-ai ask: Can you suggest a safer alternative to storing this secret?</code>
</pre>

### Preserve Org Learnings with CodeAnt
You can record team preferences so CodeAnt AI applies them in future reviews. Reply directly to the specific CodeAnt AI suggestion (in the same thread) and replace "Your feedback here" with your input:
<pre>
<code>@codeant-ai: Your feedback here</code>
</pre>
This helps CodeAnt AI learn and adapt to your team's coding style and standards.

#### Example
<pre>
<code>@codeant-ai: Do not flag unused imports.</code>
</pre>

### Retrigger review
Ask CodeAnt AI to review the PR again, by typing:
<pre>
<code>@codeant-ai: review</code>
</pre>

### Check Your Repository Health
To analyze the health of your code repository, visit our dashboard at [https://app.codeant.ai](https://app.codeant.ai). This tool helps you identify potential issues and areas for improvement in your codebase, ensuring your repository maintains high standards of code health.

</details>


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Updates now preserve existing creation audit details, such as creation time and creator, when auditing is enabled.
  - Caller-supplied changes to creation audit fields are ignored during audited updates.
  - Auditing-disabled updates continue to accept supplied creation audit values.

- **Documentation**
  - Clarified full-update behavior, audit requirements, and configuration changes.
  - Added release notes and integration coverage for the updated behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->